### PR TITLE
Simplify profile layout and remove bundled CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Narendhiranv04.github.io
+
+Minimal profile site for Narendhiran Vijayakumar, highlighting robotics and AI research, publications, projects, skills,
+and leadership. The layout follows a clean single-page structure so it can be served directly from GitHub Pages.
+
+## Local development
+
+You can preview the site locally with any static file server. One option included with Python is `http.server`:
+
+```bash
+python -m http.server 4000
+```
+
+Then open [http://localhost:4000](http://localhost:4000) in your browser.
+
+## Structure
+
+- `index.html` – page markup
+- `assets/css/styles.css` – global styles and layout
+- `assets/js/main.js` – mobile navigation toggle and footer year helper
+
+All styles and scripts are handwritten so the page has no build step or external dependencies beyond the hosted fonts.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,436 @@
+:root {
+  color-scheme: light;
+  --background: #f8fafc;
+  --surface: #ffffff;
+  --text: #1f2933;
+  --muted: #52606d;
+  --line: #d9e2ec;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+  color: var(--accent-strong);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+main section {
+  scroll-margin-top: 5.5rem;
+}
+
+.container {
+  width: min(980px, calc(100% - 3rem));
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(3rem, 6vw, 4.5rem) 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--line);
+}
+
+.section-intro {
+  max-width: 640px;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.section-intro h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 4vw, 2.3rem);
+  letter-spacing: -0.01em;
+}
+
+.section-intro p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(12px);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.1rem 0;
+}
+
+.brand {
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.nav-toggle svg {
+  width: 1rem;
+  height: 1rem;
+  stroke: currentColor;
+}
+
+.site-nav {
+  position: absolute;
+  inset: calc(100% + 0.5rem) 1.5rem auto 1.5rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.site-nav[data-open='true'] {
+  display: flex;
+}
+
+.site-nav a {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--accent-strong);
+}
+
+.hero {
+  background: var(--surface);
+}
+
+.hero__inner {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.hero__content h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.1rem, 5vw, 2.9rem);
+  letter-spacing: -0.015em;
+}
+
+.hero__content p {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  background: var(--accent-strong);
+}
+
+.fact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.fact-list li {
+  padding: 1rem 1.2rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--line);
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.fact-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.4rem;
+}
+
+.fact-list a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.fact-list a:hover,
+.fact-list a:focus {
+  text-decoration: underline;
+}
+
+.stack {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.stack--two {
+  gap: 1.25rem;
+}
+
+.item-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.item-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+}
+
+.item-meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.item-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.item-card p + p {
+  margin-top: 0.75rem;
+}
+
+.item-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--muted);
+}
+
+.publication-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.publication-list h3 {
+  font-size: 1rem;
+  margin: 0 0 0.3rem;
+}
+
+.skill-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.skill-card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  padding: 1.2rem 1.4rem;
+  box-shadow: var(--shadow);
+}
+
+.skill-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.skill-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.contact-inner {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.contact-inner h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 4vw, 2.2rem);
+}
+
+.contact-inner p {
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+}
+
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.site-footer {
+  padding: 2rem 0 2.5rem;
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.footer-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.footer-inner p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+@media (min-width: 640px) {
+  .fact-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .skill-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .site-nav {
+    position: static;
+    display: flex !important;
+    flex-direction: row;
+    gap: 1.5rem;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: transparent;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .hero__inner {
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  }
+
+  .stack--two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .skill-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,22 @@
+const navToggle = document.querySelector('.nav-toggle');
+const siteNav = document.querySelector('.site-nav');
+
+if (navToggle && siteNav) {
+  navToggle.addEventListener('click', () => {
+    const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!isExpanded));
+    siteNav.dataset.open = String(!isExpanded);
+  });
+
+  siteNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      navToggle.setAttribute('aria-expanded', 'false');
+      siteNav.dataset.open = 'false';
+    });
+  });
+}
+
+const yearNode = document.getElementById('current-year');
+if (yearNode) {
+  yearNode.textContent = new Date().getFullYear();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Narendhiran Vijayakumar · Robotics Researcher</title>
+    <meta
+      name="description"
+      content="Minimal profile site for Narendhiran Vijayakumar highlighting robotics and AI experience, publications, and leadership."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" aria-label="Primary navigation">
+      <div class="container header-inner">
+        <a class="brand" href="#top">Narendhiran Vijayakumar</a>
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+            <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+          </svg>
+          <span>Menu</span>
+          <span class="sr-only">Toggle navigation</span>
+        </button>
+        <nav id="site-navigation" class="site-nav" aria-label="Main">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#publications">Publications</a>
+          <a href="#projects">Projects</a>
+          <a href="#skills">Skills</a>
+          <a href="#leadership">Leadership</a>
+          <a href="#contact">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section id="about" class="section hero">
+        <div class="container hero__inner">
+          <div class="hero__content">
+            <p class="eyebrow">Robotics &amp; AI</p>
+            <h1>Robotics researcher focused on dependable autonomy</h1>
+            <p>
+              I build perception, motion planning, and learning systems that can leave the lab. My work blends
+              mechanical engineering fundamentals with practical machine learning to deliver reliable, human-centered
+              robotics.
+            </p>
+            <div class="button-row">
+              <a
+                class="button primary"
+                href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+                target="_blank"
+                rel="noopener"
+                >View CV</a
+              >
+              <a class="button" href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener"
+                >LinkedIn</a
+              >
+              <a class="button" href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">GitHub</a>
+            </div>
+          </div>
+          <ul class="fact-list" aria-label="Quick facts">
+            <li>
+              <span class="fact-label">Location</span>
+              <span>Chennai, India</span>
+            </li>
+            <li>
+              <span class="fact-label">Education</span>
+              <span>B.Tech Mechanical Engineering · Minor in Computer Science · NIT Tiruchirappalli (2022–2026)</span>
+            </li>
+            <li>
+              <span class="fact-label">Interests</span>
+              <span>Embodied AI, robotic perception, human-robot interaction</span>
+            </li>
+            <li>
+              <span class="fact-label">Contact</span>
+              <span>
+                <a href="mailto:narendhiranv.nitt@gmail.com">narendhiranv.nitt@gmail.com</a><br />
+                <a href="tel:+919444749184">+91 94447 49184</a>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="experience" class="section">
+        <div class="container">
+          <div class="section-intro">
+            <p class="eyebrow">Experience</p>
+            <h2>Research and engineering roles</h2>
+            <p>I bring applied machine learning into real-time control loops for autonomous systems.</p>
+          </div>
+          <div class="stack">
+            <article class="item-card">
+              <h3>Monash University · Research Intern</h3>
+              <p class="item-meta">January 2025 – May 2025</p>
+              <ul class="item-list">
+                <li>
+                  Built a lightweight GRU architecture that matched attention-LSTM accuracy for sit-to-walk torque
+                  prediction while reducing inference latency by 25%.
+                </li>
+                <li>
+                  Embedded a Mamdani fuzzy controller in an ONNX-powered C/C++ runtime to guarantee sub-2&nbsp;ms response
+                  for exoskeleton actuation.
+                </li>
+              </ul>
+            </article>
+            <article class="item-card">
+              <h3>IIT Bombay · Summer Research Intern</h3>
+              <p class="item-meta">June 2024 – September 2024</p>
+              <ul class="item-list">
+                <li>
+                  Authored APUD, ASPP-Lite, and RBRM modules to improve multi-scale context capture in drivable-area
+                  segmentation for resource-constrained robots.
+                </li>
+                <li>
+                  Delivered state-of-the-art mIoU and F1-scores on Gazebo and GMRPD datasets, outperforming YOLOP in dense
+                  scenes.
+                </li>
+              </ul>
+            </article>
+            <article class="item-card">
+              <h3>NIT Tiruchirappalli · Student Researcher</h3>
+              <p class="item-meta">2023 – 2024</p>
+              <ul class="item-list">
+                <li>
+                  Crafted real-time performance feedback for Bharatanatyam using temporal alignment and skeletal
+                  keypoints tailored to classical dance.
+                </li>
+                <li>
+                  Implemented YOLOv5-OBB on FAIR1M to capture rotated bounding boxes and benchmarked a novel fIoU metric
+                  against modern detectors.
+                </li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="publications" class="section">
+        <div class="container">
+          <div class="section-intro">
+            <p class="eyebrow">Publications</p>
+            <h2>Writing that advances perception and control</h2>
+          </div>
+          <ol class="publication-list">
+            <li>
+              <h3>Robotic Perception Through Drivable Area Segmentation Using a Hybrid Attention-Guided Approach</h3>
+              <p class="item-meta">IEEE Transactions on Artificial Intelligence · under review</p>
+            </li>
+            <li>
+              <h3>Fuzzy Logic–GRU Framework for Real-Time Sit-to-Walk Joint Torque Estimation in Robotic Exoskeletons</h3>
+              <p class="item-meta">IEEE Transactions on Neural Networks and Learning Systems · in draft</p>
+            </li>
+            <li>
+              <h3>
+                Design and Structural Validation of a Sub-2&nbsp;kg Autonomous Micro-UAV with On-Board Dynamic Route
+                Planning
+              </h3>
+              <p class="item-meta">Mechatronics and Robotics Engineering (MRAE) 2025 Conference · in draft</p>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="container">
+          <div class="section-intro">
+            <p class="eyebrow">Projects</p>
+            <h2>Selected work from competitions and side labs</h2>
+          </div>
+          <div class="stack stack--two">
+            <article class="item-card">
+              <h3>Autonomous UAS — SAE AeroTHON 2024</h3>
+              <p class="item-meta">April 2024 – November 2024</p>
+              <p>
+                Led avionics and autonomy for a top-15 quadcopter, fusing Pixhawk and Raspberry Pi controllers with ROS&nbsp;2
+                comms and NCNN-optimized SSDMobileNet-v2 detectors for 20&nbsp;ms tracking.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>PixelBot — Smart India Hackathon 2024</h3>
+              <p class="item-meta">August 2024 – September 2024</p>
+              <p>
+                Built a multimodal assistant that blends LLaVA, SAM2, and GLIGEN for segmentation, inpainting, and visual
+                reasoning with long-term context.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>MathWorks Minidrone Challenge</h3>
+              <p class="item-meta">July 2024 – August 2024</p>
+              <p>
+                Created a computer-vision guidance stack for the Parrot Mambo using adaptive morphology, cascaded PID
+                control, and virtual target tracking.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>Occlusion-Aware Navigation Toolkit</h3>
+              <p class="item-meta">March 2024</p>
+              <p>
+                Authored a Python toolkit that computes tangent arcs, masks occlusions, and generates tunable circular
+                trajectories from right-angle start poses.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="skills" class="section">
+        <div class="container">
+          <div class="section-intro">
+            <p class="eyebrow">Skills</p>
+            <h2>A systems mindset backed by hands-on tooling</h2>
+          </div>
+          <div class="skill-grid">
+            <div class="skill-card">
+              <h3>Languages</h3>
+              <p>Python, C, C++, MATLAB, Bash</p>
+            </div>
+            <div class="skill-card">
+              <h3>Frameworks &amp; Libraries</h3>
+              <p>PyTorch, TensorFlow, Keras, OpenCV, scikit-learn, MediaPipe</p>
+            </div>
+            <div class="skill-card">
+              <h3>Robotics &amp; Control</h3>
+              <p>ROS&nbsp;2, PX4, MAVROS, Ardupilot, Gazebo, QGroundControl</p>
+            </div>
+            <div class="skill-card">
+              <h3>Tools</h3>
+              <p>Git, Docker, Jupyter, LabelImg, Roboflow, Librosa, SciPy</p>
+            </div>
+            <div class="skill-card">
+              <h3>Embedded Platforms</h3>
+              <p>Raspberry Pi, Arduino, Pixhawk, Micro XRCE-DDS, Linux</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="leadership" class="section">
+        <div class="container">
+          <div class="section-intro">
+            <p class="eyebrow">Leadership</p>
+            <h2>Helping communities build with confidence</h2>
+          </div>
+          <div class="stack stack--two">
+            <article class="item-card">
+              <h3>Technical Head · Third Dimension Aeromodelling Club</h3>
+              <p class="item-meta">March 2024 – Present</p>
+              <p>
+                Guides autonomous drone development, curates avionics workshops, and mentors teams representing NIT
+                Trichy in national competitions.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>Vice President · Maximus Math &amp; Physics Society</h3>
+              <p class="item-meta">May 2025 – Present</p>
+              <p>
+                Leads project-based learning across mathematical modelling and physics-informed ML while mentoring juniors
+                through research pipelines.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>Workshops Manager · Synergy Symposium</h3>
+              <p class="item-meta">November 2023 – Present</p>
+              <p>
+                Orchestrates robotics workshops end-to-end, from speaker engagements to logistics for the flagship
+                mechanical engineering symposium.
+              </p>
+            </article>
+            <article class="item-card">
+              <h3>STEM Outreach &amp; Public Relations</h3>
+              <p class="item-meta">March 2023 – July 2024</p>
+              <p>
+                Led IGNITTE physics mentoring, directed Pragyan public relations for 1,500+ attendees, and delivered
+                robotics demonstrations that inspired school students.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section">
+        <div class="container contact-inner">
+          <div>
+            <p class="eyebrow">Let's collaborate</p>
+            <h2>Ready to build the next generation of intelligent robots</h2>
+            <p>
+              I'm excited to partner on research, internships, and conversations around embodied AI, perception, and
+              autonomy. Reach out and let's experiment together.
+            </p>
+          </div>
+          <div class="contact-actions">
+            <a class="button primary" href="mailto:narendhiranv.nitt@gmail.com">Email Narendhiran</a>
+            <a class="button" href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener"
+              >Connect on LinkedIn</a
+            >
+            <a
+              class="button"
+              href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+              target="_blank"
+              rel="noopener"
+              >View CV</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>&copy; <span id="current-year"></span> Narendhiran Vijayakumar</p>
+        <div class="footer-links">
+          <a href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">LinkedIn</a>
+          <a href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">GitHub</a>
+          <a
+            href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+            target="_blank"
+            rel="noopener"
+            >View CV</a
+          >
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restyle the landing page with a light, minimal layout that keeps the original sections but tones down the visual treatment
- simplify the navigation script and component structure for the hero, quick facts, experience, projects, skills, leadership, and contact blocks
- remove the embedded CV PDF and link to the Google Drive copy while refreshing the README to match the lean structure

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3c86276b4832cb940c4a84e3b0bad