### PR TITLE
Redesign profile page with timeline and theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # Narendhiranv04.github.io
+
+Minimal profile site for Narendhiran Vijayakumar that mirrors the look and feel of the Long Horizon Hierarchy page while
+staying lightweight. The single-page layout now includes a light/dark theme toggle, animated experience timeline, and
+project cards with dedicated media slots so the content feels intentional without heavy visuals.
+
+## Local development
+
+You can preview the site locally with any static file server. One option included with Python is `http.server`:
+
+```bash
+python -m http.server 4000
+```
+
+Then open [http://localhost:4000](http://localhost:4000) in your browser.
+
+## Structure
+
+- `index.html` – page markup and content
+- `assets/css/styles.css` – global styles, layout, and theme definitions
+- `assets/js/main.js` – navigation toggle, theme persistence, and scroll-triggered animation helpers
+- `assets/img/` – handcrafted logo marks used in the experience timeline
+
+All styles and scripts are handwritten so the page has no build step or external dependencies beyond the hosted fonts.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,753 @@
+:root {
+  color-scheme: light;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #f0f4ff;
+  --color-border: #d0d7e2;
+  --color-text: #101828;
+  --color-muted: #475467;
+  --color-accent: #2563eb;
+  --color-accent-soft: #dbeafe;
+  --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --shadow-xs: 0 8px 18px rgba(15, 23, 42, 0.06);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition-base: 220ms ease;
+}
+
+body[data-theme='dark'] {
+  color-scheme: dark;
+  --color-background: #0f172a;
+  --color-surface: #111c34;
+  --color-surface-elevated: #1b2a4b;
+  --color-border: #233250;
+  --color-text: #f8fafc;
+  --color-muted: #cbd5f5;
+  --color-accent: #60a5fa;
+  --color-accent-soft: rgba(96, 165, 250, 0.18);
+  --shadow-sm: 0 18px 38px rgba(8, 15, 38, 0.45);
+  --shadow-xs: 0 12px 24px rgba(8, 15, 38, 0.35);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--color-background);
+  color: var(--color-text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color var(--transition-base), color var(--transition-base);
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+a:hover,
+a:focus {
+  color: #1d4ed8;
+}
+
+body[data-theme='dark'] a:hover,
+body[data-theme='dark'] a:focus {
+  color: #93c5fd;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  border-radius: 12px;
+}
+
+svg {
+  display: block;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.container {
+  width: min(1100px, calc(100% - 3rem));
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(3rem, 6vw, 5rem) 0;
+}
+
+.section-head {
+  margin-bottom: clamp(1.75rem, 3vw, 2.4rem);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0 0 0.5rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: color-mix(in srgb, var(--color-background) 82%, transparent);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.brand {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-toggle,
+.nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-muted);
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color var(--transition-base), color var(--transition-base), border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.theme-toggle {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+}
+
+.theme-toggle svg,
+.nav-toggle svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible,
+.nav-toggle:hover,
+.nav-toggle:focus-visible {
+  background: var(--color-accent-soft);
+  border-color: color-mix(in srgb, var(--color-accent) 32%, var(--color-border));
+  color: var(--color-accent);
+  box-shadow: var(--shadow-xs);
+}
+
+.theme-toggle__icon {
+  display: none;
+}
+
+body[data-theme='light'] .theme-toggle__icon--sun,
+body[data-theme='dark'] .theme-toggle__icon--moon {
+  display: block;
+}
+
+.site-nav {
+  position: absolute;
+  inset: calc(100% + 0.5rem) 1.5rem auto 1.5rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.site-nav a {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.site-nav[data-open='true'] {
+  display: flex;
+}
+
+@media (min-width: 900px) {
+  .nav-toggle {
+    display: none;
+  }
+
+  .site-nav {
+    position: static;
+    display: flex !important;
+    flex-direction: row;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
+    background: transparent;
+  }
+
+  .site-nav a {
+    font-size: 0.95rem;
+    color: var(--color-muted);
+  }
+
+  .site-nav a:hover,
+  .site-nav a:focus {
+    color: var(--color-accent);
+  }
+}
+
+.hero {
+  padding-top: clamp(4rem, 10vw, 6rem);
+}
+
+.hero__grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.hero__content h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.3rem, 6vw, 3rem);
+  letter-spacing: -0.01em;
+}
+
+.hero__lead {
+  margin: 0 0 1.25rem;
+  color: var(--color-muted);
+}
+
+.hero__interests {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 1.2rem;
+}
+
+.interest-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero__bio {
+  list-style: none;
+  padding: 0;
+  margin: 1.75rem 0 1.5rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.hero__bio li {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.hero__bio-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--color-muted) 68%, var(--color-text));
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: background-color var(--transition-base), color var(--transition-base), border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.button.primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.button:hover,
+.button:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 38%, var(--color-border));
+  box-shadow: var(--shadow-xs);
+}
+
+.button.primary:hover,
+.button.primary:focus-visible {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.hero__spotlight {
+  display: grid;
+  gap: 1.25rem;
+  align-content: start;
+}
+
+.hero__card {
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.hero__card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+}
+
+body[data-theme='dark'] .hero__card:hover {
+  box-shadow: 0 18px 45px rgba(8, 15, 38, 0.6);
+}
+
+.hero__card-label {
+  margin: 0 0 0.6rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.hero__card-body {
+  margin: 0;
+  color: var(--color-text);
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.hero__timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+@media (min-width: 960px) {
+  .hero__grid {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2.2fr);
+    align-items: start;
+  }
+}
+
+.timeline {
+  position: relative;
+  padding-left: 3.5rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 1.6rem;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(180deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 50%, transparent) 100%);
+  transform: scaleY(0);
+  transform-origin: top;
+  transition: transform 1.1s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.timeline.is-visible::before {
+  transform: scaleY(1);
+}
+
+.timeline__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.timeline__item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+  opacity: 0;
+  transform: translateY(22px);
+  transition: transform 600ms cubic-bezier(0.4, 0, 0.2, 1) var(--delay),
+    opacity 600ms cubic-bezier(0.4, 0, 0.2, 1) var(--delay);
+}
+
+.timeline__item.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.timeline__node {
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  box-shadow: var(--shadow-xs);
+  display: grid;
+  place-items: center;
+  position: relative;
+  z-index: 2;
+}
+
+.timeline__node img {
+  width: 2.2rem;
+  height: 2.2rem;
+}
+
+.timeline__body {
+  padding: 1.25rem 1.4rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  box-shadow: var(--shadow-xs);
+}
+
+.timeline__header {
+  margin-bottom: 0.6rem;
+}
+
+.timeline__header h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.timeline__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.timeline__points {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .timeline {
+    padding-left: 0;
+  }
+
+  .timeline::before {
+    left: 1rem;
+  }
+
+  .timeline__item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .timeline__node {
+    margin-left: 0.5rem;
+  }
+}
+
+.publication-list {
+  list-style: decimal-leading-zero;
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.publication-list h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.2rem;
+}
+
+.item-meta {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.projects {
+  background: color-mix(in srgb, var(--color-background) 70%, var(--color-surface) 30%);
+}
+
+.project-grid {
+  display: grid;
+  gap: 1.8rem;
+}
+
+@media (min-width: 768px) {
+  .project-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.project-card {
+  display: grid;
+  gap: 1.1rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  box-shadow: var(--shadow-xs);
+  padding: 1.1rem;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  transition: transform 600ms cubic-bezier(0.4, 0, 0.2, 1) var(--delay),
+    opacity 600ms cubic-bezier(0.4, 0, 0.2, 1) var(--delay), box-shadow var(--transition-base);
+}
+
+.project-card:hover {
+  transform: translateY(-4px) scale(1.01);
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.16);
+}
+
+body[data-theme='dark'] .project-card:hover {
+  box-shadow: 0 22px 54px rgba(8, 15, 38, 0.65);
+}
+
+.project-card.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.project-card__media {
+  position: relative;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 65%, transparent), var(--color-surface));
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  display: grid;
+  place-items: center;
+}
+
+.project-card__placeholder {
+  width: 100%;
+  height: 100%;
+  border: 1px dashed color-mix(in srgb, var(--color-border) 80%, transparent);
+  border-radius: calc(var(--radius-md) - 4px);
+  display: grid;
+  place-items: center;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 70%, var(--color-text));
+  background: color-mix(in srgb, var(--color-accent-soft) 55%, transparent);
+}
+
+.project-card__content h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.project-card__meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.leadership-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .leadership-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.leadership-card {
+  padding: 1.5rem 1.6rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.leadership-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.14);
+}
+
+body[data-theme='dark'] .leadership-card:hover {
+  box-shadow: 0 20px 48px rgba(8, 15, 38, 0.6);
+}
+
+.leadership-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+}
+
+.contact .container {
+  display: grid;
+  gap: 1.2rem;
+  justify-items: start;
+}
+
+.contact-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 500;
+  transition: background-color var(--transition-base), color var(--transition-base), border-color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.contact-link__icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.contact-link:hover,
+.contact-link:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+  box-shadow: var(--shadow-xs);
+}
+
+.site-footer {
+  padding: 2rem 0 2.5rem;
+  border-top: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-background) 85%, transparent);
+}
+
+.footer__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 720px) {
+  .header__inner {
+    flex-wrap: wrap;
+  }
+
+  .header__actions {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .brand {
+    order: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/img/logos/iit-bombay.svg
+++ b/assets/img/logos/iit-bombay.svg
@@ -1,0 +1,22 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="IIT Bombay">
+  <defs>
+    <linearGradient id="iitb-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#iitb-gradient)" />
+  <g fill="#f8fafc">
+    <path
+      d="M32 15.5 28.5 13l-3 5-5-3L19 18.5l5 3-3 5 2.5 2.5 3-5 5 3 2.5-2.5-5-3 3-5Z"
+      opacity="0.85"
+    />
+    <path
+      d="M45 28a13 13 0 1 0-26 0 13 13 0 0 0 26 0Zm-21.5 0a8.5 8.5 0 1 1 17 0 8.5 8.5 0 0 1-17 0Z"
+      opacity="0.9"
+    />
+    <text x="32" y="44" text-anchor="middle" font-family="'Inter', sans-serif" font-weight="700" font-size="12">
+      IITB
+    </text>
+  </g>
+</svg>

--- a/assets/img/logos/monash.svg
+++ b/assets/img/logos/monash.svg
@@ -1,0 +1,18 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Monash University">
+  <defs>
+    <linearGradient id="monash-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#monash-gradient)" />
+  <path
+    d="M18 46V20l14 12 14-12v26h-6V31L32 38.2 24 31v15h-6Z"
+    fill="#f8fafc"
+    stroke="#f8fafc"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <circle cx="20" cy="18" r="4" fill="#f8fafc" opacity="0.6" />
+  <circle cx="44" cy="18" r="4" fill="#f8fafc" opacity="0.6" />
+</svg>

--- a/assets/img/logos/nit-trichy.svg
+++ b/assets/img/logos/nit-trichy.svg
@@ -1,0 +1,18 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NIT Tiruchirappalli">
+  <defs>
+    <linearGradient id="nitt-gradient" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fb7185" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#nitt-gradient)" />
+  <path
+    d="M20 46h24l-4-18h-4l-4 10-4-10h-4l-4 18Z"
+    fill="#fff7ed"
+    stroke="#fff7ed"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+  <path d="M20 23h24v4H20z" fill="#fff7ed" opacity="0.9" />
+  <circle cx="32" cy="18" r="4" fill="#fff7ed" opacity="0.8" />
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,113 @@
+const body = document.body;
+const navToggle = document.querySelector('.nav-toggle');
+const siteNav = document.querySelector('.site-nav');
+const themeToggle = document.querySelector('[data-theme-toggle]');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+if (navToggle && siteNav) {
+  navToggle.addEventListener('click', () => {
+    const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!isExpanded));
+    siteNav.dataset.open = String(!isExpanded);
+  });
+
+  siteNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      navToggle.setAttribute('aria-expanded', 'false');
+      siteNav.dataset.open = 'false';
+    });
+  });
+}
+
+const applyTheme = (theme, persist = true) => {
+  if (!body) return;
+  body.dataset.theme = theme;
+  if (themeToggle) {
+    const label = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+    themeToggle.setAttribute('aria-label', label);
+  }
+  if (persist) {
+    try {
+      localStorage.setItem('preferred-theme', theme);
+    } catch (error) {
+      console.warn('Unable to persist theme preference:', error);
+    }
+  }
+};
+
+const getStoredTheme = () => {
+  try {
+    return localStorage.getItem('preferred-theme');
+  } catch (error) {
+    return null;
+  }
+};
+
+const storedTheme = getStoredTheme();
+const initialTheme = storedTheme || (prefersDark.matches ? 'dark' : 'light');
+applyTheme(initialTheme, Boolean(storedTheme));
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const nextTheme = body.dataset.theme === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme);
+  });
+}
+
+prefersDark.addEventListener('change', (event) => {
+  const saved = getStoredTheme();
+  if (!saved) {
+    applyTheme(event.matches ? 'dark' : 'light', false);
+  }
+});
+
+const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+const shouldReduceMotion = reduceMotionQuery.matches;
+
+const timeline = document.querySelector('[data-animate-line]');
+const timelineItems = document.querySelectorAll('.timeline__item');
+const projectCards = document.querySelectorAll('.project-card');
+
+if (shouldReduceMotion) {
+  timeline?.classList.add('is-visible');
+  timelineItems.forEach((item) => item.classList.add('is-visible'));
+  projectCards.forEach((card) => card.classList.add('is-visible'));
+} else {
+  if (timeline) {
+    const lineObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            lineObserver.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.3 }
+    );
+
+    lineObserver.observe(timeline);
+  }
+
+  const revealObserver = new IntersectionObserver(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.35 }
+  );
+
+  [...timelineItems, ...projectCards].forEach((element, index) => {
+    element.style.setProperty('--delay', `${index * 0.12}s`);
+    revealObserver.observe(element);
+  });
+}
+
+const yearNode = document.getElementById('current-year');
+if (yearNode) {
+  yearNode.textContent = new Date().getFullYear();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,456 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Narendhiran Vijayakumar · Robotics Researcher</title>
+    <meta
+      name="description"
+      content="Profile site for Narendhiran Vijayakumar featuring robotics research, publications, projects, and contact details."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body data-theme="light">
+    <header class="site-header" aria-label="Primary navigation">
+      <div class="container header__inner">
+        <a class="brand" href="#top">Narendhiran Vijayakumar</a>
+        <div class="header__actions">
+          <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode">
+            <span class="sr-only">Toggle theme</span>
+            <svg class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true" viewBox="0 0 24 24">
+              <path
+                d="M12 4.5V2m0 20v-2.5m7.78-12.28L21.5 6.5m-19 11 1.72-1.72M4.5 12H2m20 0h-2.5m-3.9 5.9 1.77 1.77M5.4 5.4 7.17 7.17M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <svg class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true" viewBox="0 0 24 24">
+              <path
+                d="M20.45 14.35A8.5 8.5 0 0 1 9.65 3.55 8.5 8.5 0 1 0 20.45 14.35Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <button
+            class="nav-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="site-navigation"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+              <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+            </svg>
+            <span>Menu</span>
+          </button>
+        </div>
+        <nav id="site-navigation" class="site-nav" aria-label="Main navigation" data-open="false">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#publications">Publications</a>
+          <a href="#projects">Projects</a>
+          <a href="#leadership">Leadership</a>
+          <a href="#contact">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="top">
+      <section id="about" class="section hero">
+        <div class="container hero__grid">
+          <div class="hero__content">
+            <p class="eyebrow">Robotics &amp; AI</p>
+            <h1>Building reliable autonomy for people-scale robots</h1>
+            <p class="hero__lead">
+              I'm Narendhiran Vijayakumar, a robotics researcher engineering perception, planning, and control systems
+              that move seamlessly from lab experiments to the real world.
+            </p>
+            <div class="hero__interests" aria-label="Research interests">
+              <span class="interest-chip">Embodied AI</span>
+              <span class="interest-chip">Task &amp; Motion Planning</span>
+              <span class="interest-chip">Robotics</span>
+            </div>
+            <p>
+              I currently prototype intention-aware locomotion controllers for powered exoskeletons while co-designing
+              resilient autonomy stacks for aerial and mobile robots.
+            </p>
+            <ul class="hero__bio" aria-label="Profile details">
+              <li><span class="hero__bio-label">Based in</span><span>Chennai, India</span></li>
+              <li>
+                <span class="hero__bio-label">Education</span
+                ><span>B.Tech Mechanical Engineering &middot; Computer Science Minor &middot; NIT Tiruchirappalli (2022–2026)</span>
+              </li>
+              <li>
+                <span class="hero__bio-label">Contact</span
+                ><span><a href="mailto:narendhiranv.nitt@gmail.com">narendhiranv.nitt@gmail.com</a></span>
+              </li>
+            </ul>
+            <div class="button-row">
+              <a
+                class="button primary"
+                href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+                target="_blank"
+                rel="noopener"
+              >
+                <span class="button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 20 20">
+                    <path
+                      d="M10 3v10m0 0 3.5-3.5M10 13l-3.5-3.5M5 15h10"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </span>
+                <span>View CV</span>
+              </a>
+              <a class="button" href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">
+                <span class="button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 20 20">
+                    <path
+                      d="M5.4 7.2H3.2v9.6h2.2V7.2Zm-.1-4A1.4 1.4 0 1 0 3.9 4.6 1.4 1.4 0 0 0 5.3 3.2ZM16.8 11a3.6 3.6 0 0 0-3.6-3.6 3.3 3.3 0 0 0-2.4 1h-.1V7.2H8.6v9.6h2.2v-5.1c0-1.3.6-2.2 1.8-2.2s1.7.9 1.7 2.2v5.1h2.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                <span>LinkedIn</span>
+              </a>
+              <a class="button" href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">
+                <span class="button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 20 20">
+                    <path
+                      d="M10 1.8a8.2 8.2 0 0 0-2.6 16c.4.1.5-.2.5-.4v-1.5c-1.9.4-2.3-.9-2.3-.9a1.8 1.8 0 0 0-.8-1.1c-.7-.5.1-.5.1-.5a1.4 1.4 0 0 1 1 .7c.7 1.1 1.9.8 2.4.6a1.7 1.7 0 0 1 .5-1.1c-1.7-.2-3.5-.9-3.5-3.9a3 3 0 0 1 .8-2.1 2.8 2.8 0 0 1 .1-2s.7-.2 2.2.8a7.6 7.6 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8a2.8 2.8 0 0 1 .1 2 3 3 0 0 1 .8 2.1c0 3-1.8 3.7-3.5 3.9a1.9 1.9 0 0 1 .5 1.5v2.2c0 .2.1.5.5.4A8.2 8.2 0 0 0 10 1.8Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                <span>GitHub</span>
+              </a>
+            </div>
+          </div>
+          <div class="hero__spotlight">
+            <div class="hero__card">
+              <p class="hero__card-label">Currently</p>
+              <p class="hero__card-body">
+                Prototyping intention-aware locomotion controllers and safety envelopes for assistive exoskeletons at
+                Monash University.
+              </p>
+            </div>
+            <div class="hero__card hero__card--stacked">
+              <p class="hero__card-label">Recent highlights</p>
+              <ul class="hero__timeline">
+                <li>Top-15 finish at SAE AeroTHON 2024 with a custom autonomy stack for quadcopters.</li>
+                <li>Publishing a hybrid attention drivable-area segmentation pipeline from IIT Bombay research.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="experience" class="section experience">
+        <div class="container">
+          <div class="section-head">
+            <p class="eyebrow">Experience</p>
+            <h2>Timeline of research and engineering roles</h2>
+          </div>
+          <div class="timeline" data-animate-line>
+            <ol class="timeline__list">
+              <li class="timeline__item" style="--index: 0">
+                <div class="timeline__node">
+                  <img src="assets/img/logos/monash.svg" alt="Monash University logo" />
+                </div>
+                <div class="timeline__body">
+                  <div class="timeline__header">
+                    <h3>Monash University</h3>
+                    <p class="timeline__meta">Research Intern &middot; Jan 2025 – May 2025</p>
+                  </div>
+                  <ul class="timeline__points">
+                    <li>
+                      Built a lightweight GRU that matches attention-LSTM accuracy for sit-to-walk torque prediction
+                      while reducing inference latency by 25%.
+                    </li>
+                    <li>
+                      Embedded a Mamdani fuzzy controller in an ONNX-powered C/C++ runtime to guarantee sub-2&nbsp;ms
+                      actuation for exoskeleton joints.
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li class="timeline__item" style="--index: 1">
+                <div class="timeline__node">
+                  <img src="assets/img/logos/iit-bombay.svg" alt="IIT Bombay logo" />
+                </div>
+                <div class="timeline__body">
+                  <div class="timeline__header">
+                    <h3>IIT Bombay</h3>
+                    <p class="timeline__meta">Summer Research Intern &middot; Jun 2024 – Sep 2024</p>
+                  </div>
+                  <ul class="timeline__points">
+                    <li>
+                      Authored APUD, ASPP-Lite, and RBRM modules to capture multi-scale context in drivable-area
+                      segmentation for resource-constrained platforms.
+                    </li>
+                    <li>
+                      Delivered state-of-the-art mIoU and F1 scores on Gazebo and GMRPD benchmarks, outperforming YOLOP
+                      in dense traffic scenes.
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li class="timeline__item" style="--index: 2">
+                <div class="timeline__node">
+                  <img src="assets/img/logos/nit-trichy.svg" alt="NIT Tiruchirappalli logo" />
+                </div>
+                <div class="timeline__body">
+                  <div class="timeline__header">
+                    <h3>NIT Tiruchirappalli</h3>
+                    <p class="timeline__meta">Student Researcher &middot; 2023 – 2024</p>
+                  </div>
+                  <ul class="timeline__points">
+                    <li>
+                      Crafted real-time performance feedback for Bharatanatyam using temporal alignment and skeletal
+                      keypoints tuned for classical dance sequences.
+                    </li>
+                    <li>
+                      Implemented YOLOv5-OBB on FAIR1M to capture rotated bounding boxes and benchmarked a novel fIoU
+                      metric against modern detectors.
+                    </li>
+                  </ul>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section id="publications" class="section publications">
+        <div class="container">
+          <p class="eyebrow">Publications</p>
+          <ol class="publication-list">
+            <li>
+              <article>
+                <h3>Robotic Perception Through Drivable Area Segmentation Using a Hybrid Attention-Guided Approach</h3>
+                <p class="item-meta">IEEE Transactions on Artificial Intelligence &middot; Under review</p>
+              </article>
+            </li>
+            <li>
+              <article>
+                <h3>Fuzzy Logic–GRU Framework for Real-Time Sit-to-Walk Joint Torque Estimation in Robotic Exoskeletons</h3>
+                <p class="item-meta">IEEE Transactions on Neural Networks and Learning Systems &middot; In draft</p>
+              </article>
+            </li>
+            <li>
+              <article>
+                <h3>Design and Structural Validation of a Sub-2&nbsp;kg Autonomous Micro-UAV with On-Board Dynamic Route Planning</h3>
+                <p class="item-meta">Mechatronics and Robotics Engineering (MRAE) 2025 Conference &middot; In draft</p>
+              </article>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="projects" class="section projects">
+        <div class="container">
+          <div class="section-head">
+            <p class="eyebrow">Projects</p>
+            <h2>Selected builds</h2>
+          </div>
+          <div class="project-grid">
+            <article class="project-card" style="--index: 0">
+              <div class="project-card__media" aria-hidden="true">
+                <div class="project-card__placeholder">Image coming soon</div>
+              </div>
+              <div class="project-card__content">
+                <h3>Autonomous UAS — SAE AeroTHON 2024</h3>
+                <p class="project-card__meta">April 2024 – November 2024</p>
+                <p>
+                  Led avionics and autonomy for a top-15 quadcopter, fusing Pixhawk and Raspberry Pi controllers with
+                  ROS&nbsp;2 comms and NCNN-optimized SSDMobileNet-v2 detectors for 20&nbsp;ms tracking.
+                </p>
+              </div>
+            </article>
+            <article class="project-card" style="--index: 1">
+              <div class="project-card__media" aria-hidden="true">
+                <div class="project-card__placeholder">Image coming soon</div>
+              </div>
+              <div class="project-card__content">
+                <h3>PixelBot — Smart India Hackathon 2024</h3>
+                <p class="project-card__meta">August 2024 – September 2024</p>
+                <p>
+                  Built a multimodal assistant blending LLaVA, SAM2, and GLIGEN for segmentation, inpainting, and visual
+                  reasoning with persistent memory.
+                </p>
+              </div>
+            </article>
+            <article class="project-card" style="--index: 2">
+              <div class="project-card__media" aria-hidden="true">
+                <div class="project-card__placeholder">Image coming soon</div>
+              </div>
+              <div class="project-card__content">
+                <h3>MathWorks Minidrone Challenge</h3>
+                <p class="project-card__meta">July 2024 – August 2024</p>
+                <p>
+                  Created a computer-vision guidance stack for the Parrot Mambo using adaptive morphology, cascaded PID
+                  control, and virtual target tracking for agile indoor flight.
+                </p>
+              </div>
+            </article>
+            <article class="project-card" style="--index: 3">
+              <div class="project-card__media" aria-hidden="true">
+                <div class="project-card__placeholder">Image coming soon</div>
+              </div>
+              <div class="project-card__content">
+                <h3>Occlusion-Aware Navigation Toolkit</h3>
+                <p class="project-card__meta">March 2024</p>
+                <p>
+                  Authored a Python toolkit to compute tangent arcs, mask occlusions, and generate tunable circular
+                  trajectories from right-angle start poses.
+                </p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="leadership" class="section leadership">
+        <div class="container">
+          <div class="section-head">
+            <p class="eyebrow">Leadership</p>
+            <h2>Communities I help grow</h2>
+          </div>
+          <div class="leadership-grid">
+            <article class="leadership-card">
+              <h3>Technical Head &middot; Third Dimension Aeromodelling Club</h3>
+              <p class="item-meta">March 2024 – Present</p>
+              <p>
+                Guides autonomous drone development, curates avionics workshops, and mentors teams representing NIT
+                Trichy in national competitions.
+              </p>
+            </article>
+            <article class="leadership-card">
+              <h3>Vice President &middot; Maximus Math &amp; Physics Society</h3>
+              <p class="item-meta">May 2025 – Present</p>
+              <p>
+                Leads project-based learning across mathematical modelling and physics-informed ML while mentoring junior
+                members through research pipelines.
+              </p>
+            </article>
+            <article class="leadership-card">
+              <h3>Workshops Manager &middot; Synergy Symposium</h3>
+              <p class="item-meta">November 2023 – Present</p>
+              <p>
+                Orchestrates robotics workshops end-to-end, from speaker engagements to logistics for the flagship
+                mechanical engineering symposium.
+              </p>
+            </article>
+            <article class="leadership-card">
+              <h3>STEM Outreach &amp; Public Relations</h3>
+              <p class="item-meta">March 2023 – July 2024</p>
+              <p>
+                Led IGNITTE physics mentoring, directed Pragyan public relations for 1,500+ attendees, and delivered
+                robotics demonstrations for school students.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section contact">
+        <div class="container">
+          <p class="eyebrow">Let's collaborate</p>
+          <div class="contact-links">
+            <a class="contact-link" href="mailto:narendhiranv.nitt@gmail.com">
+              <span class="contact-link__icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20">
+                  <path
+                    d="M3.3 5.5h13.4a1.3 1.3 0 0 1 1.3 1.3v6.4a1.3 1.3 0 0 1-1.3 1.3H3.3a1.3 1.3 0 0 1-1.3-1.3V6.8a1.3 1.3 0 0 1 1.3-1.3Zm0 1.2 6.7 4 6.7-4m-6.7 4L3.2 13.7m6.8-2.9 6.5 2.9"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span>Email</span>
+            </a>
+            <a class="contact-link" href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">
+              <span class="contact-link__icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20">
+                  <path
+                    d="M5.4 7.2H3.2v9.6h2.2V7.2Zm-.1-4A1.4 1.4 0 1 0 3.9 4.6 1.4 1.4 0 0 0 5.3 3.2ZM16.8 11a3.6 3.6 0 0 0-3.6-3.6 3.3 3.3 0 0 0-2.4 1h-.1V7.2H8.6v9.6h2.2v-5.1c0-1.3.6-2.2 1.8-2.2s1.7.9 1.7 2.2v5.1h2.5Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              <span>LinkedIn</span>
+            </a>
+            <a class="contact-link" href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">
+              <span class="contact-link__icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20">
+                  <path
+                    d="M10 1.8a8.2 8.2 0 0 0-2.6 16c.4.1.5-.2.5-.4v-1.5c-1.9.4-2.3-.9-2.3-.9a1.8 1.8 0 0 0-.8-1.1c-.7-.5.1-.5.1-.5a1.4 1.4 0 0 1 1 .7c.7 1.1 1.9.8 2.4.6a1.7 1.7 0 0 1 .5-1.1c-1.7-.2-3.5-.9-3.5-3.9a3 3 0 0 1 .8-2.1 2.8 2.8 0 0 1 .1-2s.7-.2 2.2.8a7.6 7.6 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8a2.8 2.8 0 0 1 .1 2 3 3 0 0 1 .8 2.1c0 3-1.8 3.7-3.5 3.9a1.9 1.9 0 0 1 .5 1.5v2.2c0 .2.1.5.5.4A8.2 8.2 0 0 0 10 1.8Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              <span>GitHub</span>
+            </a>
+            <a
+              class="contact-link"
+              href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+              target="_blank"
+              rel="noopener"
+            >
+              <span class="contact-link__icon" aria-hidden="true">
+                <svg viewBox="0 0 20 20">
+                  <path
+                    d="M10 3v10m0 0 3.5-3.5M10 13l-3.5-3.5M5 15h10"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span>CV</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__inner">
+        <p>&copy; <span id="current-year"></span> Narendhiran Vijayakumar</p>
+        <div class="footer-links">
+          <a href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">LinkedIn</a>
+          <a href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">GitHub</a>
+          <a
+            href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
+            target="_blank"
+            rel="noopener"
+            >CV</a
+          >
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the hero and quick-facts introduction with research interest badges, icon CTAs, and a light/dark theme toggle
- replace the experience cards with an animated logo timeline and refresh publications, projects, and contact sections per the requested minimal template
- update the global styles, scripts, and documentation to support theme persistence, scroll-triggered reveals, and handcrafted institute logos

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3c86276b4832cb940c4a84e3b0bad