### PR TITLE
Revise hero section layout for portrait placeholder

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -393,9 +393,36 @@ body[data-theme='dark'] .theme-toggle__icon--moon {
 
 /* Spotlight cards */
 .hero__spotlight {
-  display: grid;
-  gap: 1.25rem;
-  align-content: start;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.hero__portrait-frame {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.hero__portrait {
+  width: min(320px, 100%);
+  aspect-ratio: 3 / 4;
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  background: radial-gradient(circle at 30% 30%, rgba(37, 99, 235, 0.18), transparent 60%),
+    linear-gradient(160deg, color-mix(in srgb, var(--surface) 80%, var(--accent) 20%), var(--surface));
+  box-shadow: var(--shadow-sm);
+}
+
+.hero__portrait-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
 .hero__card {

--- a/index.html
+++ b/index.html
@@ -72,8 +72,7 @@
       <section id="about" class="section hero">
         <div class="container hero__grid">
           <div class="hero__content">
-            <p class="eyebrow">Robotics &amp; AI</p>
-            <h1>Robotics researcher focused on dependable autonomy</h1>
+            <h1>Narendhiran Vijayakumar</h1>
             <p class="hero__lead">
               I build perception, motion planning, and learning systems that can leave the lab. My work blends
               mechanical engineering fundamentals with practical machine learning to deliver reliable, human‑centered robotics.
@@ -140,20 +139,14 @@
             </div>
           </div>
           <div class="hero__spotlight">
-            <div class="hero__card">
-              <p class="hero__card-label">Currently</p>
-              <p class="hero__card-body">
-                Prototyping intention‑aware locomotion controllers and safety envelopes for assistive exoskeletons at
-                Monash University.
-              </p>
-            </div>
-            <div class="hero__card hero__card--stacked">
-              <p class="hero__card-label">Recent highlights</p>
-              <ul class="hero__timeline">
-                <li>Top‑15 finish at SAE AeroTHON 2024 with a custom autonomy stack for quadcopters.</li>
-                <li>Publishing a hybrid‑attention drivable‑area segmentation pipeline from IIT Bombay research.</li>
-              </ul>
-            </div>
+            <figure class="hero__portrait-frame">
+              <div
+                class="hero__portrait"
+                role="img"
+                aria-label="Portrait of Narendhiran Vijayakumar coming soon"
+              ></div>
+              <figcaption class="hero__portrait-caption">Portrait coming soon</figcaption>
+            </figure>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- remove the robotics tagline in the hero section and promote the name as the primary heading
- clear the “Currently” and “Recent highlights” cards to make space for a dedicated portrait placeholder
- style the new portrait frame and caption so a future photo can drop in cleanly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59085aeb0832c90915d32d2325d75