### PR TITLE
Streamline hero hero focus and portrait

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -69,6 +69,10 @@ body {
   transition: background-color var(--transition-base), color var(--transition-base);
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 a {
   color: var(--accent);
   text-decoration: none;
@@ -179,12 +183,51 @@ main section {
   padding: 1.1rem 0;
 }
 
-.brand {
-  font-weight: 600;
-  font-size: 1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text);
+.header__socials {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.header__social-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--muted);
+  transition: background-color var(--transition-base), color var(--transition-base), border-color var(--transition-base),
+    box-shadow var(--transition-base), transform var(--transition-base);
+}
+
+.header__social-link svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.header__social-link:hover,
+.header__social-link:focus-visible {
+  background: var(--color-accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--line));
+  color: var(--accent);
+  box-shadow: var(--shadow-xs);
+  transform: translateY(-1px);
+}
+
+body[data-theme='dark'] .header__social-link {
+  background: color-mix(in srgb, var(--surface) 85%, rgba(96, 165, 250, 0.22));
+  border-color: color-mix(in srgb, var(--line) 55%, transparent);
+  color: color-mix(in srgb, var(--muted) 75%, #fff 25%);
+}
+
+body[data-theme='dark'] .header__social-link:hover,
+body[data-theme='dark'] .header__social-link:focus-visible {
+  background: color-mix(in srgb, rgba(96, 165, 250, 0.32) 70%, transparent);
+  border-color: color-mix(in srgb, rgba(147, 197, 253, 0.7) 60%, transparent);
+  color: #fff;
 }
 
 .header__actions {
@@ -273,69 +316,177 @@ body[data-theme='dark'] .theme-toggle__icon--moon {
 
 /* Hero */
 .hero {
-  background: var(--surface);
+  position: relative;
   padding-top: clamp(4rem, 10vw, 6rem);
+  background: linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--surface) 88%, var(--color-accent-soft) 12%) 0%,
+      var(--surface) 55%,
+      color-mix(in srgb, var(--surface) 92%, var(--color-accent-soft) 8%) 100%
+    );
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.65;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.hero::before {
+  width: clamp(22rem, 40vw, 32rem);
+  height: clamp(22rem, 40vw, 32rem);
+  top: clamp(-12rem, -6vw, -8rem);
+  right: clamp(-14rem, -8vw, -6rem);
+  background: radial-gradient(circle at 30% 30%, rgba(37, 99, 235, 0.22), transparent 70%);
+}
+
+.hero::after {
+  width: clamp(18rem, 36vw, 28rem);
+  height: clamp(18rem, 36vw, 28rem);
+  bottom: clamp(-12rem, -8vw, -6rem);
+  left: clamp(-14rem, -10vw, -8rem);
+  background: radial-gradient(circle at 70% 70%, rgba(59, 130, 246, 0.18), transparent 65%);
 }
 
 .hero__grid,
 .hero__inner {
+  position: relative;
+  z-index: 1;
   display: grid;
-  gap: clamp(2rem, 5vw, 3rem);
+  gap: clamp(2rem, 5vw, 3.2rem);
+}
+
+.hero__grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.hero__content {
+  display: grid;
+  gap: 1.1rem;
+  max-width: 640px;
 }
 
 .hero__content h1 {
-  margin: 0 0 1rem;
-  font-size: clamp(2.1rem, 5vw, 2.9rem);
-  letter-spacing: -0.015em;
+  margin: 0;
+  font-size: clamp(2.3rem, 6vw, 3.1rem);
+  letter-spacing: -0.02em;
 }
 
-.hero__lead,
-.hero__content p {
-  margin: 0 0 1.5rem;
-  color: var(--muted);
+.hero__tagline {
+  margin: 0;
+  color: color-mix(in srgb, var(--text) 92%, var(--muted));
+  font-size: clamp(1.12rem, 2.8vw, 1.32rem);
+  font-weight: 500;
+  letter-spacing: -0.01em;
 }
 
-.hero__interests {
+.hero__summary {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 88%, var(--text));
+  line-height: 1.75;
+  max-width: 62ch;
+}
+
+.hero__topics {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
-  margin-bottom: 1.2rem;
+  gap: 0.55rem;
 }
 
-.interest-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0.85rem;
+.hero__topics li {
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
-  background: var(--color-accent-soft);
-  color: var(--accent);
-  font-size: 0.75rem;
+  background: color-mix(in srgb, rgba(37, 99, 235, 0.14) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--accent-strong);
   font-weight: 600;
+  font-size: 0.92rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.hero__bio {
-  list-style: none;
-  padding: 0;
-  margin: 1.75rem 0 1.5rem;
-  display: grid;
-  gap: 0.85rem;
+[data-animate] {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: hero-fade-up 0.9s cubic-bezier(0.33, 1, 0.68, 1) forwards;
+  animation-delay: var(--hero-delay, 0s);
 }
 
-.hero__bio li {
-  display: grid;
-  gap: 0.4rem;
-  font-size: 0.95rem;
-  color: var(--muted);
+@keyframes hero-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.hero__bio-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  color: color-mix(in srgb, var(--muted) 68%, var(--text));
+@keyframes hero-float {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-0.6deg);
+  }
+  50% {
+    transform: translateY(-12px) rotate(0.6deg);
+  }
+}
+
+body[data-theme='dark'] .hero {
+  background: linear-gradient(
+      140deg,
+      color-mix(in srgb, var(--surface) 88%, rgba(37, 99, 235, 0.14)) 0%,
+      color-mix(in srgb, var(--surface) 95%, rgba(96, 165, 250, 0.12)) 100%
+    );
+}
+
+body[data-theme='dark'] .hero::before {
+  background: radial-gradient(circle at 30% 30%, rgba(96, 165, 250, 0.22), transparent 70%);
+}
+
+body[data-theme='dark'] .hero::after {
+  background: radial-gradient(circle at 70% 70%, rgba(56, 189, 248, 0.22), transparent 65%);
+}
+
+body[data-theme='dark'] .hero__tagline {
+  color: color-mix(in srgb, var(--text) 80%, rgba(203, 213, 225, 0.6));
+}
+
+body[data-theme='dark'] .hero__summary {
+  color: color-mix(in srgb, var(--muted) 80%, rgba(226, 232, 240, 0.65));
+}
+
+body[data-theme='dark'] .hero__topics li {
+  background: color-mix(in srgb, rgba(59, 130, 246, 0.3) 80%, transparent);
+  border-color: color-mix(in srgb, rgba(147, 197, 253, 0.65) 45%, transparent);
+  color: rgba(224, 242, 254, 0.92);
+}
+
+body[data-theme='dark'] .hero__spotlight::before {
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.28), transparent 65%);
+}
+
+body[data-theme='dark'] .hero__portrait {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.78), rgba(14, 116, 144, 0.68));
+  box-shadow: 0 28px 65px rgba(8, 15, 38, 0.6);
+}
+
+body[data-theme='dark'] .hero__portrait::before {
+  border-color: color-mix(in srgb, rgba(147, 197, 253, 0.45) 60%, transparent);
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--surface) 80%, transparent) 0%, rgba(30, 64, 175, 0.35) 100%),
+    repeating-linear-gradient(135deg, rgba(96, 165, 250, 0.12) 0 12px, transparent 12px 24px);
 }
 
 /* Buttons */
@@ -391,11 +542,79 @@ body[data-theme='dark'] .theme-toggle__icon--moon {
   height: 1.2rem;
 }
 
-/* Spotlight cards */
+/* Spotlight */
 .hero__spotlight {
-  display: grid;
-  gap: 1.25rem;
-  align-content: start;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.hero__spotlight::before {
+  content: '';
+  position: absolute;
+  top: 55%;
+  left: 50%;
+  width: clamp(28rem, 52vw, 38rem);
+  height: clamp(28rem, 52vw, 38rem);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.22), transparent 65%);
+  filter: blur(12px);
+  opacity: 0.75;
+  transform: translate(-50%, -20%);
+  z-index: 0;
+}
+
+.hero__portrait-frame {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.hero__portrait {
+  position: relative;
+  width: clamp(340px, 48vw, 560px);
+  aspect-ratio: 3 / 4;
+  border-radius: 34px;
+  padding: 8px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.75), rgba(14, 165, 233, 0.55));
+  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+  animation: hero-float 9s ease-in-out infinite;
+}
+
+.hero__portrait::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 28px;
+  border: 1px dashed color-mix(in srgb, var(--line) 75%, transparent);
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--surface) 92%, transparent) 0%, color-mix(in srgb, var(--color-accent-soft) 70%, transparent) 100%),
+    repeating-linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0 12px, transparent 12px 24px);
+}
+
+.hero__portrait::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 34px;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.25), transparent 35%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.hero__portrait-caption {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 75%, var(--text));
 }
 
 .hero__card {
@@ -824,6 +1043,10 @@ body[data-theme='dark'] .project-card:hover {
   .nav-toggle {
     display: none;
   }
+  .hero__grid {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+    align-items: center;
+  }
   .hero__inner {
     grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
   }
@@ -854,5 +1077,12 @@ body[data-theme='dark'] .project-card:hover {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  [data-animate] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  .hero__portrait {
+    animation: none !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -19,7 +19,59 @@
   <body data-theme="light">
     <header class="site-header" aria-label="Primary navigation">
       <div class="container header__inner">
-        <a class="brand" href="#top">Narendhiran Vijayakumar</a>
+        <div class="header__socials" aria-label="Social links">
+          <a
+            class="header__social-link"
+            href="https://www.linkedin.com/in/narendhiranv04"
+            target="_blank"
+            rel="noopener"
+            aria-label="LinkedIn"
+          >
+            <svg viewBox="0 0 20 20" aria-hidden="true">
+              <path
+                d="M5.4 7.2H3.2v9.6h2.2V7.2Zm-.1-4A1.4 1.4 0 1 0 3.9 4.6 1.4 1.4 0 0 0 5.3 3.2ZM16.8 11a3.6 3.6 0 0 0-3.6-3.6 3.3 3.3 0 0 0-2.4 1h-.1V7.2H8.6v9.6h2.2v-5.1c0-1.3.6-2.2 1.8-2.2s1.7.9 1.7 2.2v5.1h2.5Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span class="sr-only">LinkedIn</span>
+          </a>
+          <a
+            class="header__social-link"
+            href="https://github.com/Narendhiranv04"
+            target="_blank"
+            rel="noopener"
+            aria-label="GitHub"
+          >
+            <svg viewBox="0 0 20 20" aria-hidden="true">
+              <path
+                d="M10 1.8a8.2 8.2 0 0 0-2.6 16c.4.1.5-.2.5-.4v-1.5c-1.9.4-2.3-.9-2.3-.9a1.8 1.8 0 0 0-.8-1.1c-.7-.5.1-.5.1-.5a1.4 1.4 0 0 1 1 .7c.7 1.1 1.9.8 2.4.6a1.7 1.7 0 0 1 .5-1.1c-1.7-.2-3.5-.9-3.5-3.9a3 3 0 0 1 .8-2.1 2.8 2.8 0 0 1 .1-2s.7-.2 2.2.8a7.6 7.6 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8a2.8 2.8 0 0 1 .1 2 3 3 0 0 1 .8 2.1c0 3-1.8 3.7-3.5 3.9a1.9 1.9 0 0 1 .5 1.5v2.2c0 .2.1.5.5.4A8.2 8.2 0 0 0 10 1.8Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span class="sr-only">GitHub</span>
+          </a>
+          <a class="header__social-link" href="mailto:narendhiranv.nitt@gmail.com" aria-label="Email">
+            <svg viewBox="0 0 20 20" aria-hidden="true">
+              <path
+                d="M3.5 5.5h13a1 1 0 0 1 1 1v7.8a1 1 0 0 1-1 1h-13a1 1 0 0 1-1-1V6.5a1 1 0 0 1 1-1Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="m4 7 6 4 6-4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span class="sr-only">Email</span>
+          </a>
+        </div>
         <div class="header__actions">
           <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch to dark mode">
             <span class="sr-only">Toggle theme</span>
@@ -72,29 +124,21 @@
       <section id="about" class="section hero">
         <div class="container hero__grid">
           <div class="hero__content">
-            <p class="eyebrow">Robotics &amp; AI</p>
-            <h1>Robotics researcher focused on dependable autonomy</h1>
-            <p class="hero__lead">
-              I build perception, motion planning, and learning systems that can leave the lab. My work blends
-              mechanical engineering fundamentals with practical machine learning to deliver reliable, human‑centered robotics.
+            <h1 data-animate style="--hero-delay: 0.05s">
+              <span class="no-wrap">Narendhiran Vijayakumar</span>
+            </h1>
+            <p class="hero__tagline" data-animate style="--hero-delay: 0.18s">
+              Undergraduate robotics researcher at NIT Tiruchirappalli designing autonomy that earns people’s trust.
             </p>
-            <div class="hero__interests" aria-label="Research interests">
-              <span class="interest-chip">Embodied AI</span>
-              <span class="interest-chip">Task &amp; Motion Planning</span>
-              <span class="interest-chip">Robotics</span>
-            </div>
-            <ul class="hero__bio" aria-label="Profile details">
-              <li><span class="hero__bio-label">Based in</span><span>Chennai, India</span></li>
-              <li>
-                <span class="hero__bio-label">Education</span
-                ><span>B.Tech Mechanical Engineering · Minor in CS · NIT Tiruchirappalli (2022–2026)</span>
-              </li>
-              <li>
-                <span class="hero__bio-label">Contact</span
-                ><span><a href="mailto:narendhiranv.nitt@gmail.com">narendhiranv.nitt@gmail.com</a></span>
-              </li>
+            <p class="hero__summary" data-animate style="--hero-delay: 0.32s">
+              I prototype perception, control, and decision-making systems that ship on drones, exoskeletons, and vision-guided platforms—bridging research with dependable field deployments.
+            </p>
+            <ul class="hero__topics" data-animate style="--hero-delay: 0.46s">
+              <li>Embodied AI</li>
+              <li>Robotics</li>
+              <li>Task &amp; Motion Planning</li>
             </ul>
-            <div class="button-row">
+            <div class="button-row" data-animate style="--hero-delay: 0.6s">
               <a
                 class="button primary"
                 href="https://drive.google.com/file/d/1SyGD0DjldZzbLfe_uZA7Cfn02GoxvzdS/view?usp=sharing"
@@ -114,6 +158,29 @@
                   </svg>
                 </span>
                 <span>View CV</span>
+              </a>
+              <a class="button" href="mailto:narendhiranv.nitt@gmail.com">
+                <span class="button__icon" aria-hidden="true">
+                  <svg viewBox="0 0 20 20">
+                    <path
+                      d="M3.5 5.5h13a1 1 0 0 1 1 1v7.8a1 1 0 0 1-1 1h-13a1 1 0 0 1-1-1V6.5a1 1 0 0 1 1-1Z"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="m4 7 6 4 6-4"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </span>
+                <span>Email</span>
               </a>
               <a class="button" href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">
                 <span class="button__icon" aria-hidden="true">
@@ -139,21 +206,15 @@
               </a>
             </div>
           </div>
-          <div class="hero__spotlight">
-            <div class="hero__card">
-              <p class="hero__card-label">Currently</p>
-              <p class="hero__card-body">
-                Prototyping intention‑aware locomotion controllers and safety envelopes for assistive exoskeletons at
-                Monash University.
-              </p>
-            </div>
-            <div class="hero__card hero__card--stacked">
-              <p class="hero__card-label">Recent highlights</p>
-              <ul class="hero__timeline">
-                <li>Top‑15 finish at SAE AeroTHON 2024 with a custom autonomy stack for quadcopters.</li>
-                <li>Publishing a hybrid‑attention drivable‑area segmentation pipeline from IIT Bombay research.</li>
-              </ul>
-            </div>
+          <div class="hero__spotlight" data-animate style="--hero-delay: 0.45s">
+            <figure class="hero__portrait-frame">
+              <div
+                class="hero__portrait"
+                role="img"
+                aria-label="Portrait of Narendhiran Vijayakumar coming soon"
+              ></div>
+              <figcaption class="hero__portrait-caption">Portrait coming soon</figcaption>
+            </figure>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- remove the three detail highlight blocks from the hero and replace them with a concise Embodied AI / Robotics / Task & Motion Planning topics row
- keep the header left side limited to icon links and enlarge the hero portrait frame and glow to better fill the reserved space
- adjust hero styling to support the new topic chips and larger portrait while keeping the CTA row intact

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d59085aeb0832c90915d32d2325d75