### PR TITLE
Revamp research timeline layout

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -198,22 +198,114 @@ if ('IntersectionObserver' in window && sections.length) {
   navLinks[0].classList.add('is-active');
 }
 
-// Add this new script content to your existing script.js file
+// --- RESEARCH TIMELINE ---
+const researchExperiences = [
+  {
+    title: 'Embodied AI Intern',
+    organization: 'NTU, Singapore',
+    timeframe: 'May 2025 – Present',
+    summary:
+      'Extended Moto-VLA with contrastive learning and in-context memory for retrieval-augmented VLA control.',
+    image: {
+      src: 'https://placehold.co/120x120?text=NTU',
+      alt: 'Placeholder logo for NTU Singapore',
+    },
+  },
+  {
+    title: 'Task & Motion Planning Intern',
+    organization: 'IIIT, Hyderabad',
+    timeframe: 'July 2025 – Present',
+    summary:
+      'Designed a contract-validated visual HRL framework for long-horizon manipulation tasks using MoE and SmolVLA controllers.',
+    image: {
+      src: 'https://placehold.co/120x120?text=IIIT',
+      alt: 'Placeholder logo for IIIT Hyderabad',
+    },
+  },
+  {
+    title: 'Assistive Robotics Intern',
+    organization: 'Monash University',
+    timeframe: 'Jan 2025 – May 2025',
+    summary:
+      'Developed a lightweight GRU for real-time torque prediction in robotic exoskeletons with a fuzzy logic-based control system.',
+    image: {
+      src: 'https://placehold.co/120x120?text=Monash',
+      alt: 'Placeholder logo for Monash University',
+    },
+  },
+  {
+    title: 'Robotic Perception Intern',
+    organization: 'IIT Bombay',
+    timeframe: 'Jun 2024 – Feb 2025',
+    summary:
+      'Developed AURASeg, a model for drivable area segmentation, outperforming YOLOP in mIoU and F1-score.',
+    image: {
+      src: 'https://placehold.co/120x120?text=IIT+B',
+      alt: 'Placeholder logo for IIT Bombay',
+    },
+  },
+];
 
-document.addEventListener('DOMContentLoaded', () => {
-  const timelineItems = document.querySelectorAll('.timeline-item');
+const researchTimeline = document.querySelector('[data-js="research-timeline"]');
 
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('is-visible');
+if (researchTimeline) {
+  researchExperiences.forEach((experience, index) => {
+    const item = document.createElement('article');
+    item.className = 'timeline-item';
+    item.style.setProperty('--animation-index', index.toString());
+
+    const imageWrapper = document.createElement('div');
+    imageWrapper.className = 'timeline-image';
+
+    const img = document.createElement('img');
+    img.src = experience.image.src;
+    img.alt = experience.image.alt;
+    img.loading = 'lazy';
+    imageWrapper.appendChild(img);
+
+    const content = document.createElement('div');
+    content.className = 'timeline-content';
+
+    const meta = document.createElement('p');
+    meta.className = 'timeline-meta';
+
+    const strong = document.createElement('strong');
+    strong.textContent = experience.organization;
+    meta.append(strong);
+    meta.append(document.createTextNode(` · ${experience.timeframe}`));
+
+    const heading = document.createElement('h3');
+    heading.textContent = experience.title;
+
+    const description = document.createElement('p');
+    description.className = 'timeline-description';
+    description.textContent = experience.summary;
+
+    content.append(meta, heading, description);
+    item.append(imageWrapper, content);
+    researchTimeline.appendChild(item);
+  });
+
+  const timelineItems = researchTimeline.querySelectorAll('.timeline-item');
+
+  if ('IntersectionObserver' in window) {
+    const timelineObserver = new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        });
+      },
+      {
+        threshold: 0.35,
+        rootMargin: '0px 0px -10% 0px',
       }
-    });
-  }, {
-    threshold: 0.1
-  });
+    );
 
-  timelineItems.forEach(item => {
-    observer.observe(item);
-  });
-});
+    timelineItems.forEach((item) => timelineObserver.observe(item));
+  } else {
+    timelineItems.forEach((item) => item.classList.add('is-visible'));
+  }
+}
+

--- a/assets/style.css
+++ b/assets/style.css
@@ -495,33 +495,6 @@ section {
   margin: 0 auto;
 }
 
-.about-grid {
-  display: grid;
-  gap: 1.35rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.about-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  padding: 1.5rem;
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.about-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.about-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
 /* ================== */
 /* Section header row */
 /* ================== */
@@ -1007,37 +980,46 @@ section {
   }
   
 }
-/* Add these new styles to the end of your existing style.css file */
+/* =================== */
+/* Research timeline   */
+/* =================== */
 
 .timeline-section {
-  padding: 4rem 0;
+  padding: 4.5rem 0;
 }
 
 .timeline {
   position: relative;
-  max-width: 750px;
+  max-width: 920px;
   margin: 0 auto;
+  padding-bottom: 2rem;
 }
 
 .timeline::after {
   content: '';
   position: absolute;
-  width: 6px;
-  background-color: var(--border);
   top: 0;
   bottom: 0;
   left: 50%;
-  margin-left: -3px;
+  transform: translateX(-50%);
+  width: 4px;
+  background: linear-gradient(
+    180deg,
+    var(--color-accent-soft) 0%,
+    var(--color-accent) 45%,
+    var(--color-accent-soft) 100%
+  );
+  opacity: 0.8;
 }
 
 .timeline-item {
-  padding: 1rem 2.5rem;
   position: relative;
-  background-color: inherit;
   width: 50%;
+  padding: 0 2.75rem 2.75rem;
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  transform: translateY(48px);
+  transition: transform 0.6s ease, opacity 0.6s ease;
+  transition-delay: calc(var(--animation-index, 0) * 0.12s);
 }
 
 .timeline-item.is-visible {
@@ -1047,102 +1029,133 @@ section {
 
 .timeline-item:nth-child(odd) {
   left: 0;
+  text-align: left;
 }
 
 .timeline-item:nth-child(even) {
   left: 50%;
 }
 
-.timeline-item::after {
+.timeline-item::before {
   content: '';
   position: absolute;
-  width: 25px;
-  height: 25px;
-  right: -17px;
-  background-color: var(--background);
-  border: 4px solid var(--accent);
-  top: 15px;
+  top: 24px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
+  border: 3px solid var(--color-accent);
+  background: var(--color-bg);
+  box-shadow: 0 0 0 4px rgba(123, 131, 255, 0.12);
   z-index: 1;
 }
 
-.timeline-item:nth-child(even)::after {
-  left: -16px;
+.timeline-item:nth-child(odd)::before {
+  right: -8px;
+}
+
+.timeline-item:nth-child(even)::before {
+  left: -8px;
 }
 
 .timeline-image {
   position: absolute;
-  top: 0;
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  top: -12px;
+  width: 96px;
+  height: 96px;
+  border-radius: 16px;
   overflow: hidden;
-  border: 3px solid var(--accent-glow);
-  background: var(--surface);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  border: 2px solid rgba(123, 131, 255, 0.32);
+  background: var(--color-surface);
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-sm);
 }
 
 .timeline-item:nth-child(odd) .timeline-image {
-  right: -130px;
+  right: -152px;
 }
 
 .timeline-item:nth-child(even) .timeline-image {
-  left: -130px;
+  left: -152px;
 }
 
 .timeline-image img {
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
 }
 
 .timeline-content {
-  padding: 1.25rem;
-  background-color: var(--surface);
   position: relative;
-  border-radius: 6px;
-  border: 1px solid var(--border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.65rem;
 }
 
-@media screen and (max-width: 768px) {
+.timeline-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  color: var(--color-muted);
+}
+
+.timeline-content h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-family: var(--font-display);
+  color: var(--color-heading);
+}
+
+.timeline-description {
+  margin: 0;
+  color: var(--color-text);
+}
+
+@media (max-width: 960px) {
+  .timeline-section {
+    padding: 3.5rem 0;
+  }
+
   .timeline::after {
-    left: 31px;
+    left: 24px;
+    transform: none;
   }
 
   .timeline-item {
     width: 100%;
-    padding-left: 70px;
-    padding-right: 25px;
+    padding: 0 0 2.5rem 3.5rem;
   }
 
-  .timeline-item:nth-child(odd) {
-    left: 0;
-  }
-  
   .timeline-item:nth-child(even) {
     left: 0;
   }
 
-  .timeline-item::after {
-    left: 15px;
+  .timeline-item::before {
+    left: 8px;
   }
 
-  .timeline-item:nth-child(even)::after {
-    left: 15px;
-  }
-  
   .timeline-image {
     position: static;
-    width: 60px;
-    height: 60px;
+    width: 80px;
+    height: 80px;
     margin-bottom: 1rem;
   }
-  
+
   .timeline-item:nth-child(odd) .timeline-image,
   .timeline-item:nth-child(even) .timeline-image {
-    position: absolute;
-    left: -100px;
-    top: 0;
+    right: auto;
+    left: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-item {
+    transition: none;
+    transform: none;
+    opacity: 1;
   }
 }

--- a/index.html
+++ b/index.html
@@ -128,44 +128,7 @@
           <p class="section-subtitle">
             A snapshot of my research internships and contributions to the field of robotics and AI.
           </p>
-          <div class="timeline">
-            <div class="timeline-item">
-              <div class="timeline-image">
-                <img src="https://via.placeholder.com/150" alt="NTU Singapore Logo">
-              </div>
-              <div class="timeline-content">
-                <h3>Embodied AI Intern</h3>
-                <p><strong>NTU, Singapore (May 2025 – Present)</strong><br>Extended Moto-VLA with contrastive learning and in-context memory for retrieval-augmented VLA control.</p>
-              </div>
-            </div>
-            <div class="timeline-item">
-              <div class="timeline-image">
-                <img src="https://via.placeholder.com/150" alt="IIIT Hyderabad Logo">
-              </div>
-              <div class="timeline-content">
-                <h3>Task & Motion Planning Intern</h3>
-                <p><strong>IIIT, Hyderabad (July 2025 – Present)</strong><br>Designed a contract-validated visual HRL framework for long-horizon manipulation tasks using MoE and SmolVLA controllers.</p>
-              </div>
-            </div>
-            <div class="timeline-item">
-              <div class="timeline-image">
-                <img src="https://via.placeholder.com/150" alt="Monash University Logo">
-              </div>
-              <div class="timeline-content">
-                <h3>Assistive Robotics Intern</h3>
-                <p><strong>Monash University (Jan 2025 – May 2025)</strong><br>Developed a lightweight GRU for real-time torque prediction in robotic exoskeletons with a fuzzy logic-based control system.</p>
-              </div>
-            </div>
-            <div class="timeline-item">
-              <div class="timeline-image">
-                <img src="https://via.placeholder.com/150" alt="IIT Bombay Logo">
-              </div>
-              <div class="timeline-content">
-                <h3>Robotic Perception Intern</h3>
-                <p><strong>IIT Bombay (Jun 2024 – Feb 2025)</strong><br>Developed AURASeg, a model for drivable area segmentation, outperforming YOLOP in mIoU and F1-score.</p>
-              </div>
-            </div>
-          </div>
+          <div class="timeline" data-js="research-timeline"></div>
         </div>
       </section>
       


### PR DESCRIPTION
## Summary
- remove the unused About Me styling block so the section is fully dropped
- replace the hard-coded research entries with a JS-driven timeline that injects placeholders for each institute
- refresh the timeline styling to support alternating items and scroll-triggered animation

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de40dc5958832c9f713594b05f5b37