### PR TITLE
Rebuild publications section and flagship projects

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -309,131 +309,355 @@ if (researchTimeline) {
   }
 }
 
-// --- PROJECT GALLERY ---
-const projects = [
+// --- PUBLICATIONS ---
+const publicationGroups = [
   {
-    title: 'Autonomous UAS',
-    tag: 'Aerial Robotics',
-    meta: 'SAE AeroTHON · 2024',
-    summary:
-      'Led the development of an autonomous quadcopter platform with custom perception pipelines and ROS 2 integrations that finished top 15 nationwide.',
-    image: {
-      src: 'https://placehold.co/960x720/0f172a/ffffff?text=Autonomous+UAS',
-      alt: 'Placeholder hero image representing the Autonomous UAS project.',
-    },
+    title: 'In Preparation',
+    description:
+      'Finalising manuscripts that extend our embodied AI agenda before upcoming submission deadlines.',
+    milestone: 'Next submissions: IROS 2026 & RA-L Q4 2025.',
+    items: [
+      {
+        title:
+          'Contrastive Latent-Action Retrieval with In-Context Memory for Robotic Manipulation',
+        authors: 'N. Vijayakumar, R. Li, Z. Wang*',
+        venue: 'IROS · 2026 (target)',
+        status: 'Manuscript drafting',
+        summary:
+          'Retrieval-augmented visual-language-action policy that composes latent actions using on-the-fly memory tokens for long-horizon manipulation.',
+        highlights: [
+          'Contrastive retrieval bank distilled from teleoperation rollouts.',
+          'Memory prompting keeps novel task success stable with minimal finetuning.',
+        ],
+      },
+      {
+        title:
+          'Contract-Validated Option Selection with MoE RL for Long-Horizon Manipulation',
+        authors: 'N. Vijayakumar, P. Ojha, G. Varma, A. Thomas*',
+        venue: 'RA-L · 2025 (target)',
+        status: 'Experiments wrapping up',
+        summary:
+          'Mixture-of-experts reinforcement learning stack that enforces contract-based guarantees when sequencing manipulation skills.',
+        highlights: [
+          'Safety contracts for reachability and force compliance baked into option selection.',
+          'Bridges sim-to-real with curriculum resets and human-in-the-loop validation.',
+        ],
+      },
+    ],
   },
   {
-    title: 'PixelBot',
-    tag: 'Multimodal AI',
-    meta: 'Smart India Hackathon · 2024',
-    summary:
-      'Built a multimodal assistant for image-centric workflows using LLaVA, SAM2, and GLIGEN with staged reasoning and evaluation utilities.',
-    image: {
-      src: 'https://placehold.co/960x720/101935/ffffff?text=PixelBot',
-      alt: 'Placeholder hero image representing the PixelBot project.',
-    },
-    highlights: ['Secured 2nd place in the Smart India Hackathon qualifier.'],
-  },
-  {
-    title: 'Line-Following Parrot MAMBO',
-    tag: 'Embedded Autonomy',
-    meta: 'MathWorks Minidrone Challenge · 2023',
-    summary:
-      'Engineered a vision pipeline and Stateflow planner in Simulink to guide the Parrot Mambo microdrone around dynamic track markers.',
-    image: {
-      src: 'https://placehold.co/960x720/111c3d/ffffff?text=Parrot+Mambo',
-      alt: 'Placeholder hero image representing the Parrot Mambo autonomy project.',
-    },
-  },
-  {
-    title: 'Occlusion Masking – Avoidance Algorithm',
-    tag: 'Independent Project',
-    meta: 'March 2024',
-    summary:
-      'Developed a Python navigation toolkit for 300×300 occupancy grids that computes tangent arcs and masks occlusions to negotiate cluttered scenes.',
-    image: {
-      src: 'https://placehold.co/960x720/0c1a33/ffffff?text=Occlusion+Masking',
-      alt: 'Placeholder hero image representing the occlusion masking avoidance project.',
-    },
-    highlights: [
-      'Integrated tangent-arc computation with masking techniques for obstacle avoidance.',
-      'Enabled circular movement with adjustable radii and efficient paths from a 90° start orientation.',
+    title: 'Under Review',
+    description: 'Peer-reviewed submissions currently in editorial pipelines.',
+    milestone: 'Actively responding to reviewer feedback across three venues.',
+    items: [
+      {
+        title:
+          'Fuzzy Logic–GRU Framework for Real-Time Sit-to-Walk Joint Torque Estimation',
+        authors: 'C. Perera, N. Vijayakumar, A. Agape*',
+        venue: 'IEEE TNNLS · 2025 (under review)',
+        status: 'Initial review cycle',
+        summary:
+          'Lightweight hybrid estimator for exoskeleton torque prediction that blends fuzzy rules with recurrent dynamics for comfort-critical assistive walking.',
+        highlights: [
+          'Adaptive membership functions tuned for sit-to-walk transitions.',
+          'Embedded deployment on STM32 with <2 ms inference latency.',
+        ],
+      },
+      {
+        title:
+          'AURASeg: Attention Guided Upsampling with Residual Boundary-Assistive Refinement',
+        authors: 'N. Vijayakumar*, M. Sridevi',
+        venue: 'Signal, Image and Video Processing · 2025 (under review)',
+        status: 'Awaiting reviewer scores',
+        summary:
+          'Semantic segmentation pipeline for drivable area detection that sharpens occlusion boundaries with residual refinement.',
+        highlights: [
+          'Dual-branch attention for balancing texture cues and layout context.',
+          'Residual boundary assist improves edge IoU on nuScenes val split.',
+        ],
+      },
+      {
+        title: 'Design and Validation of a Micro-UAV with Dynamic Route Planning',
+        authors: 'N. Vijayakumar*, I. Ravikumar, R. Sundhar',
+        venue: 'ICMRAE · 2025 (under review)',
+        status: 'Camera-ready pending',
+        summary:
+          'Micro air vehicle platform with adaptive waypoint planning and robust failsafes for indoor autonomy demos.',
+        highlights: [
+          'On-board route planner adapts to moving obstacles in 3D grids.',
+          'Flight-tested guidance stack with redundant telemetry and watchdogs.',
+        ],
+      },
     ],
   },
 ];
 
-const projectsGallery = document.querySelector('[data-js="projects-gallery"]');
+const publicationContainer = document.querySelector('[data-js="publication-groups"]');
 
-if (projectsGallery) {
-  projects.forEach((project, index) => {
-    const card = document.createElement('article');
-    card.className = 'project-card';
-    card.style.setProperty('--animation-index', index.toString());
-    card.setAttribute('tabindex', '0');
+if (publicationContainer) {
+  publicationGroups.forEach((group, index) => {
+    const wrapper = document.createElement('article');
+    wrapper.className = 'publication-group';
+    wrapper.style.setProperty('--animation-index', index.toString());
 
-    const media = document.createElement('div');
-    media.className = 'project-card__media';
+    const header = document.createElement('header');
+    header.className = 'publication-group__header';
 
-    const img = document.createElement('img');
-    img.src = project.image.src;
-    img.alt = project.image.alt;
-    img.loading = 'lazy';
-    media.appendChild(img);
+    const badge = document.createElement('span');
+    badge.className = 'publication-group__badge';
+    badge.textContent = group.title;
 
-    const overlay = document.createElement('div');
-    overlay.className = 'project-card__overlay';
+    const description = document.createElement('p');
+    description.className = 'publication-group__description';
+    description.textContent = group.description;
 
-    const overlayInner = document.createElement('div');
-    overlayInner.className = 'project-card__overlay-inner';
+    header.append(badge, description);
 
-    const header = document.createElement('div');
-    header.className = 'project-card__header';
-
-    const title = document.createElement('h3');
-    title.className = 'project-card__title';
-    title.textContent = project.title;
-    header.appendChild(title);
-
-    if (project.tag) {
-      const tag = document.createElement('span');
-      tag.className = 'project-card__tag';
-      tag.textContent = project.tag;
-      header.appendChild(tag);
+    if (group.milestone) {
+      const milestone = document.createElement('p');
+      milestone.className = 'publication-group__milestone';
+      milestone.textContent = group.milestone;
+      header.appendChild(milestone);
     }
 
-    const body = document.createElement('div');
-    body.className = 'project-card__body';
+    const list = document.createElement('ul');
+    list.className = 'publication-list';
 
-    if (project.meta) {
-      const meta = document.createElement('p');
-      meta.className = 'project-card__meta';
-      meta.textContent = project.meta;
-      body.appendChild(meta);
-    }
+    group.items.forEach((item) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'publication-card';
 
-    const summary = document.createElement('p');
-    summary.className = 'project-card__summary';
-    summary.textContent = project.summary;
-    body.appendChild(summary);
+      const meta = document.createElement('div');
+      meta.className = 'publication-card__meta';
 
-    if (Array.isArray(project.highlights) && project.highlights.length) {
-      const list = document.createElement('ul');
-      list.className = 'project-card__highlights';
-      project.highlights.forEach((item) => {
-        const li = document.createElement('li');
-        li.textContent = item;
-        list.appendChild(li);
-      });
-      body.appendChild(list);
-    }
+      const venue = document.createElement('span');
+      venue.className = 'publication-card__venue';
+      venue.textContent = item.venue;
 
-    overlayInner.append(header, body);
-    overlay.appendChild(overlayInner);
-    card.append(media, overlay);
-    projectsGallery.appendChild(card);
+      const status = document.createElement('span');
+      status.className = 'publication-card__status';
+      status.textContent = item.status;
+
+      meta.append(venue, status);
+
+      const title = document.createElement('h3');
+      title.className = 'publication-card__title';
+      title.textContent = item.title;
+
+      const authors = document.createElement('p');
+      authors.className = 'publication-card__authors';
+      authors.textContent = item.authors;
+
+      const summary = document.createElement('p');
+      summary.className = 'publication-card__summary';
+      summary.textContent = item.summary;
+
+      listItem.append(meta, title, authors, summary);
+
+      if (Array.isArray(item.highlights) && item.highlights.length) {
+        const highlights = document.createElement('ul');
+        highlights.className = 'publication-card__highlights';
+
+        item.highlights.forEach((highlight) => {
+          const highlightItem = document.createElement('li');
+          highlightItem.textContent = highlight;
+          highlights.appendChild(highlightItem);
+        });
+
+        listItem.appendChild(highlights);
+      }
+
+      list.appendChild(listItem);
+    });
+
+    wrapper.append(header, list);
+    publicationContainer.appendChild(wrapper);
   });
 
-  const projectCards = projectsGallery.querySelectorAll('.project-card');
+  const publicationGroupsEls = publicationContainer.querySelectorAll('.publication-group');
+
+  if ('IntersectionObserver' in window) {
+    const publicationObserver = new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        });
+      },
+      {
+        threshold: 0.3,
+        rootMargin: '0px 0px -10% 0px',
+      }
+    );
+
+    publicationGroupsEls.forEach((group) => publicationObserver.observe(group));
+  } else {
+    publicationGroupsEls.forEach((group) => group.classList.add('is-visible'));
+  }
+}
+
+// --- FLAGSHIP PROJECTS ---
+const flagshipProjects = [
+  {
+    title: 'Autonomous UAS',
+    focus: 'Aerial Robotics · Systems Lead',
+    timeframe: 'SAE AeroTHON · 2024',
+    description:
+      'Led the systems team delivering a competition-ready quadcopter with full autonomy stack, resilient perception, and safety interlocks.',
+    highlights: [
+      'Modular ROS 2 stack spanning mission planning, guidance, and PX4-based control.',
+      'Vision-driven landing pipeline with adaptive AprilTag filtering for gusty outdoor runs.',
+      'Mission rehearsals validated autonomous sorties under changing payload configurations.',
+    ],
+    technologies: ['ROS 2', 'PX4 Autopilot', 'OpenCV', 'NVIDIA Jetson'],
+    outcome:
+      'Top-15 national finish with sustained autonomous flight across endurance, payload drop, and navigation tasks.',
+  },
+  {
+    title: 'PixelBot Multimodal Assistant',
+    focus: 'Multimodal AI · Team Lead',
+    timeframe: 'Smart India Hackathon · 2024',
+    description:
+      'Built a co-pilot for image-centric workflows that blends grounded visual question answering with controllable generative edits.',
+    highlights: [
+      'Staged reasoning harnessing LLaVA for analysis, SAM2 for masks, and GLIGEN for guided synthesis.',
+      'Pipeline orchestration with async task queue delivering responses under 4 seconds per request.',
+      'Evaluation harness with curated benchmarks for instruction-following and edit fidelity.',
+    ],
+    technologies: ['Python', 'LLaVA', 'SAM2', 'FastAPI', 'Redis'],
+    outcome:
+      'Secured 2nd place in the national qualifier while open-sourcing reusable evaluation utilities.',
+  },
+  {
+    title: 'Parrot Mambo Autonomy Challenge',
+    focus: 'Embedded Autonomy · Controls Engineer',
+    timeframe: 'MathWorks Minidrone Challenge · 2023',
+    description:
+      'Engineered a lightweight autonomy stack for the Parrot Mambo microdrone using MATLAB/Simulink for rapid iteration.',
+    highlights: [
+      'Stateflow-based mission planner with guard conditions for dynamic gate ordering.',
+      'Custom lane-detection vision filters running at 60 FPS on-board the drone.',
+      'Hardware-in-the-loop validation that reduced oscillations during tight turns.',
+    ],
+    technologies: ['MATLAB', 'Simulink', 'Stateflow', 'Embedded Coder'],
+    outcome:
+      'Achieved fully autonomous line-following with reliable gate traversal in final demos.',
+  },
+  {
+    title: 'Occlusion-Aware Avoidance Toolkit',
+    focus: 'Independent Research · Motion Planning',
+    timeframe: 'March 2024',
+    description:
+      'Developed a Python toolkit for navigation on dense occupancy grids with occlusion-aware path reasoning.',
+    highlights: [
+      'Tangent-arc computation with masked visibility cones to negotiate cluttered spaces.',
+      'Parameterised curvature profiles enabling smooth transitions from 90° start orientations.',
+      'Interactive visualiser for debugging candidate paths and clearance margins.',
+    ],
+    technologies: ['Python', 'NumPy', 'Shapely', 'Matplotlib'],
+    outcome:
+      'Adopted in internal autonomy experiments for rapid what-if analysis of navigation policies.',
+  },
+];
+
+const projectShowcase = document.querySelector('[data-js="project-showcase"]');
+
+if (projectShowcase) {
+  flagshipProjects.forEach((project, index) => {
+    const article = document.createElement('article');
+    article.className = 'project-case';
+    article.style.setProperty('--animation-index', index.toString());
+
+    const summary = document.createElement('div');
+    summary.className = 'project-case__summary';
+
+    const eyebrow = document.createElement('p');
+    eyebrow.className = 'project-case__eyebrow';
+    eyebrow.textContent = `${project.focus}`;
+
+    const title = document.createElement('h3');
+    title.className = 'project-case__title';
+    title.textContent = project.title;
+
+    const description = document.createElement('p');
+    description.className = 'project-case__description';
+    description.textContent = project.description;
+
+    summary.append(eyebrow, title, description);
+
+    if (Array.isArray(project.highlights) && project.highlights.length) {
+      const highlightList = document.createElement('ul');
+      highlightList.className = 'project-case__highlights';
+
+      project.highlights.forEach((highlight) => {
+        const li = document.createElement('li');
+        li.textContent = highlight;
+        highlightList.appendChild(li);
+      });
+
+      summary.appendChild(highlightList);
+    }
+
+    const details = document.createElement('div');
+    details.className = 'project-case__details';
+
+    const timelineBlock = document.createElement('div');
+    timelineBlock.className = 'project-case__meta-block';
+
+    const timelineLabel = document.createElement('span');
+    timelineLabel.className = 'project-case__meta-label';
+    timelineLabel.textContent = 'Stage';
+
+    const timelineValue = document.createElement('span');
+    timelineValue.className = 'project-case__meta-value';
+    timelineValue.textContent = project.timeframe;
+
+    timelineBlock.append(timelineLabel, timelineValue);
+    details.appendChild(timelineBlock);
+
+    if (project.technologies && project.technologies.length) {
+      const techBlock = document.createElement('div');
+      techBlock.className = 'project-case__meta-block';
+
+      const techLabel = document.createElement('span');
+      techLabel.className = 'project-case__meta-label';
+      techLabel.textContent = 'Stack';
+
+      const techList = document.createElement('ul');
+      techList.className = 'project-case__tech-list';
+
+      project.technologies.forEach((tech) => {
+        const techItem = document.createElement('li');
+        techItem.textContent = tech;
+        techList.appendChild(techItem);
+      });
+
+      techBlock.append(techLabel, techList);
+      details.appendChild(techBlock);
+    }
+
+    if (project.outcome) {
+      const outcomeBlock = document.createElement('div');
+      outcomeBlock.className = 'project-case__meta-block project-case__meta-block--accent';
+
+      const outcomeLabel = document.createElement('span');
+      outcomeLabel.className = 'project-case__meta-label';
+      outcomeLabel.textContent = 'Outcome';
+
+      const outcomeValue = document.createElement('span');
+      outcomeValue.className = 'project-case__meta-value';
+      outcomeValue.textContent = project.outcome;
+
+      outcomeBlock.append(outcomeLabel, outcomeValue);
+      details.appendChild(outcomeBlock);
+    }
+
+    article.append(summary, details);
+    projectShowcase.appendChild(article);
+  });
+
+  const projectCases = projectShowcase.querySelectorAll('.project-case');
 
   if ('IntersectionObserver' in window) {
     const projectObserver = new IntersectionObserver(
@@ -445,47 +669,13 @@ if (projectsGallery) {
         });
       },
       {
-        threshold: 0.35,
+        threshold: 0.3,
         rootMargin: '0px 0px -10% 0px',
       }
     );
 
-    projectCards.forEach((card) => projectObserver.observe(card));
+    projectCases.forEach((card) => projectObserver.observe(card));
   } else {
-    projectCards.forEach((card) => card.classList.add('is-visible'));
+    projectCases.forEach((card) => card.classList.add('is-visible'));
   }
-
-  const deactivateAll = () => {
-    projectCards.forEach((card) => card.classList.remove('is-active'));
-  };
-
-  projectCards.forEach((card) => {
-    card.addEventListener('click', () => {
-      const isActivating = !card.classList.contains('is-active');
-      deactivateAll();
-      if (isActivating) {
-        card.classList.add('is-active');
-      }
-    });
-
-    card.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        const isActivating = !card.classList.contains('is-active');
-        deactivateAll();
-        if (isActivating) {
-          card.classList.add('is-active');
-        }
-      } else if (event.key === 'Escape') {
-        card.classList.remove('is-active');
-        card.blur();
-      }
-    });
-  });
-
-  document.addEventListener('click', (event) => {
-    if (!projectsGallery.contains(event.target)) {
-      deactivateAll();
-    }
-  });
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -567,292 +567,390 @@ section {
   line-height: 1.6;
 }
 
-/* =============== */
-/* Architecture UI */
-/* =============== */
-.architecture {
+/* ================= */
+/* Publications area */
+/* ================= */
+.results {
+  padding: clamp(3rem, 6vw, 4.5rem) 0;
+}
+
+.publication-groups {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.publication-group {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(
+      135deg,
+      rgba(123, 131, 255, 0.12),
+      transparent 45%
+    ),
+    var(--color-surface);
+  padding: clamp(1.85rem, 4vw, 2.65rem);
+  box-shadow: var(--shadow-soft);
+  transform: translateY(42px);
+  opacity: 0;
+  transition: transform 0.55s cubic-bezier(0.21, 0.78, 0.35, 1),
+    opacity 0.55s ease;
+  transition-delay: calc(var(--animation-index, 0) * 90ms);
+}
+
+.publication-group::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at top right,
+    rgba(123, 131, 255, 0.25),
+    transparent 55%
+  );
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+.publication-group > * {
+  position: relative;
+  z-index: 1;
+}
+
+.publication-group.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.publication-group__header {
+  display: grid;
+  gap: 0.65rem;
+  margin-bottom: clamp(1.25rem, 3vw, 1.85rem);
+}
+
+.publication-group__badge {
+  width: fit-content;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(123, 131, 255, 0.22);
+  color: var(--color-heading);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.publication-group__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+  max-width: 60ch;
+}
+
+.publication-group__milestone {
+  margin: 0;
+  color: var(--color-heading);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.publication-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.15rem;
+}
+
+.publication-card {
+  border-radius: clamp(1rem, 3vw, 1.35rem);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(12, 18, 36, 0.55);
+  backdrop-filter: blur(14px);
+  padding: clamp(1.35rem, 3.5vw, 1.75rem);
+  display: grid;
+  gap: 0.75rem;
+}
+
+body[data-theme='light'] .publication-card {
+  background: rgba(255, 255, 255, 0.8);
+  border-color: rgba(49, 46, 129, 0.12);
+}
+
+.publication-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.publication-card__venue {
+  font-weight: 600;
+}
+
+.publication-card__status {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(123, 131, 255, 0.2);
+  color: var(--color-heading);
+  font-weight: 600;
+}
+
+.publication-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.2rem, 3vw, 1.55rem);
+  color: var(--color-heading);
+}
+
+.publication-card__authors {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.publication-card__summary {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.publication-card__highlights {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--color-muted);
+  font-size: 0.92rem;
+}
+
+.publication-card__highlights li {
+  margin: 0;
+  position: relative;
+}
+
+.publication-card__highlights li::marker {
+  color: var(--color-accent);
+}
+
+@media (max-width: 720px) {
+  .publication-card__meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .publication-group {
+    transform: none !important;
+    opacity: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* ================= */
+/* Flagship projects */
+/* ================= */
+.portfolio {
   background: var(--color-section);
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 }
 
-.project-gallery {
+.project-showcase {
   display: grid;
   gap: clamp(1.75rem, 4vw, 2.5rem);
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.project-card {
+.project-case {
   position: relative;
   overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+  padding: clamp(2rem, 4.5vw, 2.85rem);
   border-radius: var(--radius-lg);
-  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(
+      135deg,
+      rgba(123, 131, 255, 0.18),
+      transparent 55%
+    ),
+    var(--color-surface);
   box-shadow: var(--shadow-soft);
   transform: translateY(48px);
   opacity: 0;
-  --project-overlay-peek: clamp(6.25rem, 12vw, 8.5rem);
-  transition: transform 0.75s cubic-bezier(0.21, 0.78, 0.35, 1),
-    opacity 0.75s ease,
-    box-shadow var(--transition);
-  transition-delay: calc(var(--animation-index, 0) * 90ms),
-    calc(var(--animation-index, 0) * 90ms),
-    0s;
+  transition: transform 0.6s cubic-bezier(0.21, 0.78, 0.35, 1),
+    opacity 0.6s ease;
+  transition-delay: calc(var(--animation-index, 0) * 110ms);
 }
 
-.project-card.is-visible {
-  transform: translateY(0);
-  opacity: 1;
-}
-
-.project-card.is-active,
-.project-card:hover,
-.project-card:focus-visible {
-  box-shadow: var(--shadow-elevated);
-}
-
-.project-card:focus-visible {
-  outline: 2px solid var(--color-outline);
-  outline-offset: 4px;
-}
-
-.project-card__media {
-  position: relative;
-  isolation: isolate;
-}
-
-.project-card__media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  aspect-ratio: 4 / 3;
-  transition: transform 0.7s ease, filter 0.7s ease;
-}
-
-.project-card.is-active .project-card__media img,
-.project-card:hover .project-card__media img,
-.project-card:focus-visible .project-card__media img {
-  transform: scale(1.05);
-  filter: saturate(1.05);
-}
-
-.project-card__overlay {
+.project-case::before {
+  content: '';
   position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: stretch;
-  padding: clamp(1.85rem, 4.5vw, 2.85rem);
-  background: linear-gradient(
-    186deg,
-    rgba(18, 28, 60, 0.94) 0%,
-    rgba(14, 23, 50, 0.95) 52%,
-    rgba(10, 17, 38, 0.97) 100%
+  inset: -35% -20% 40% 45%;
+  background: radial-gradient(
+    circle at top,
+    rgba(123, 131, 255, 0.4),
+    transparent 65%
   );
-  color: #f6f8ff;
-  transform: translateY(calc(-100% + var(--project-overlay-peek)));
-  transition: transform 0.55s ease, background 0.55s ease,
-    box-shadow 0.55s ease;
+  opacity: 0.55;
   pointer-events: none;
 }
 
-.project-card.is-active .project-card__overlay,
-.project-card:hover .project-card__overlay,
-.project-card:focus-visible .project-card__overlay,
-.project-card:focus-within .project-card__overlay {
+.project-case > * {
+  position: relative;
+  z-index: 1;
+}
+
+.project-case.is-visible {
   transform: translateY(0);
-  background: linear-gradient(
-    184deg,
-    rgba(79, 93, 176, 0.94) 0%,
-    rgba(44, 58, 128, 0.97) 45%,
-    rgba(16, 24, 56, 0.99) 100%
-  );
+  opacity: 1;
 }
 
-.project-card__overlay-inner {
+.project-case__summary {
   display: grid;
-  grid-template-rows: auto 1fr;
-  align-content: start;
-  gap: clamp(1.2rem, 3vw, 1.85rem);
-  pointer-events: auto;
-  width: 100%;
-  height: 100%;
+  gap: clamp(0.85rem, 2.5vw, 1.4rem);
 }
 
-.project-card__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-  padding-bottom: 0.85rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.16);
-}
-
-.project-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.95rem;
-}
-
-.project-card__tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  width: fit-content;
-  padding: 0.4rem 0.85rem;
-  border-radius: 999px;
-  background: rgba(123, 131, 255, 0.2);
-  color: rgba(232, 236, 255, 0.95);
-  font-size: 0.82rem;
-  font-weight: 600;
+.project-case__eyebrow {
+  margin: 0;
+  font-size: 0.9rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--color-muted);
 }
 
-.project-card__title {
+.project-case__title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(1.55rem, 4.2vw, 2.05rem);
-  color: inherit;
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
+  color: var(--color-heading);
 }
 
-.project-card__meta {
+.project-case__description {
   margin: 0;
-  font-size: 0.92rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(220, 226, 255, 0.82);
-}
-
-.project-card__summary {
-  margin: 0;
-  color: rgba(241, 245, 255, 0.94);
+  color: var(--color-text);
   font-size: 1rem;
-  line-height: 1.7;
-  max-width: 56ch;
-  opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  line-height: 1.65;
+  max-width: 58ch;
 }
 
-.project-card.is-active .project-card__summary,
-.project-card:hover .project-card__summary,
-.project-card:focus-visible .project-card__summary,
-.project-card:focus-within .project-card__summary {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.project-card__highlights {
+.project-case__highlights {
   margin: 0;
-  padding-left: 1.15rem;
+  padding: 0;
+  list-style: none;
   display: grid;
   gap: 0.65rem;
-  color: rgba(224, 230, 255, 0.9);
-  font-size: 0.98rem;
-  line-height: 1.6;
-  opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.45s ease 40ms, transform 0.45s ease 40ms;
 }
 
-.project-card__highlights li {
+.project-case__highlights li {
   margin: 0;
+  padding-left: 1.35rem;
+  position: relative;
+  color: var(--color-muted);
+  font-size: 0.97rem;
+  line-height: 1.6;
 }
 
-.project-card.is-active .project-card__highlights,
-.project-card:hover .project-card__highlights,
-.project-card:focus-visible .project-card__highlights,
-.project-card:focus-within .project-card__highlights {
-  opacity: 1;
-  transform: translateY(0);
+.project-case__highlights li::before {
+  content: '✶';
+  position: absolute;
+  left: 0;
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  top: 0.35rem;
 }
 
-@media (max-width: 640px) {
-  .project-gallery {
+.project-case__details {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.project-case__meta-block {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(9, 14, 28, 0.55);
+}
+
+body[data-theme='light'] .project-case__meta-block {
+  background: rgba(255, 255, 255, 0.82);
+  border-color: rgba(49, 46, 129, 0.12);
+}
+
+.project-case__meta-block--accent {
+  background: rgba(123, 131, 255, 0.22);
+  border-color: rgba(123, 131, 255, 0.45);
+}
+
+.project-case__meta-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.project-case__meta-value {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.project-case__tech-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.project-case__tech-list li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(123, 131, 255, 0.16);
+  color: var(--color-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .project-case {
     grid-template-columns: 1fr;
   }
 
-  .project-card__overlay {
-    transform: translateY(
-      calc(-100% + clamp(5.5rem, 16vw, 7rem))
-    );
+  .project-case__details {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .project-case__details {
+    grid-template-columns: 1fr;
+  }
+
+  .project-case__meta-block {
+    padding: 0.85rem 1rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .project-card,
-  .project-card__media img,
-  .project-card__overlay,
-  .project-card__summary,
-  .project-card__highlights {
+  .project-case {
+    transform: none !important;
+    opacity: 1 !important;
     transition-duration: 0.001ms !important;
-    transition-delay: 0ms !important;
   }
-
-  .project-card {
-    transform: none !important;
-    opacity: 1 !important;
-  }
-
-  .project-card__overlay {
-    transform: none !important;
-  }
-
-  .project-card__summary {
-    opacity: 1 !important;
-    transform: none !important;
-  }
-
-  .project-card__highlights {
-    opacity: 1 !important;
-    transform: none !important;
-  }
-}
-
-/* ============ */
-/* Results area */
-/* ============ */
-.results {
-  padding: 3rem 0;
-}
-
-.results__grid,
-.result-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.result-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.25rem;
-  display: grid;
-  gap: 1rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.result-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.result-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.media-placeholder {
-  display: grid;
-  place-items: center;
-  aspect-ratio: 16 / 9;
-  border-radius: 16px;
-  background: var(--color-section);
-  border: 1px dashed var(--color-border);
-  color: var(--color-muted);
-  font-size: 0.9rem;
-  text-align: center;
-  padding: 0.75rem;
 }
 
 /* ================== */

--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         >
           <a href="#overview">Overview</a>
           <a href="#research">Research</a>
-          <a href="#projects">Projects</a>
           <a href="#publications">Publications</a>
+          <a href="#projects">Projects</a>
           <a href="#media">Media</a>
           <a href="#resources">Resources</a>
           <a href="#contact">Contact</a>
@@ -132,45 +132,29 @@
         </div>
       </section>
       
-      <!-- ================ -->
-      <!-- Projects section -->
-      <!-- ================ -->
-      <section class="architecture" id="projects">
-        <div class="container">
-          <h2 class="section-title">Selected Projects</h2>
-          <p class="section-subtitle">
-            From hackathons to design contests, here are a few initiatives that capture my work.
-          </p>
-          <div class="project-gallery" data-js="projects-gallery"></div>
-        </div>
-      </section>
-
       <!-- ===================== -->
       <!-- Publications section -->
       <!-- ===================== -->
       <section class="results" id="publications">
         <div class="container">
-          <h2 class="section-title">Publications &amp; Preprints</h2>
+          <h2 class="section-title">Publications</h2>
           <p class="section-subtitle">
             A complete list is available on Google Scholar. * indicates corresponding author.
           </p>
-          <div class="results-grid">
-            <article class="result-card">
-              <h3>In Preparation</h3>
-              <ul>
-                <li>N. Vijayakumar, R. Li, Z. Wang*, “Contrastive Latent-Action Retrieval with In-Context Memory for Robotic Manipulation,” <em>IROS</em>, 2026.</li>
-                <li>N. Vijayakumar, P. Ojha, G. Varma, A. Thomas*, “Contract-Validated Option Selection with MoE RL for Long-Horizon Manipulation,” <em>RA-L</em>, 2025.</li>
-              </ul>
-            </article>
-            <article class="result-card">
-              <h3>Under Review</h3>
-              <ul>
-                <li>C. Perera, N. Vijayakumar, A. Agape*, “Fuzzy Logic–GRU Framework for Real-Time Sit-to-Walk Joint Torque Estimation,” <em>TNNLS</em>, 2025.</li>
-                <li>N. Vijayakumar*, M. Sridevi, “AURASeg: Attention Guided Upsampling with Residual Boundary-Assistive Refinement,” <em>SIVP</em>, 2025.</li>
-                <li>N. Vijayakumar*, I. Ravikumar, R. Sundhar, “Design and Validation of a Micro-UAV with Dynamic Route Planning,” <em>ICMRAE</em>, 2025.</li>
-              </ul>
-            </article>
-          </div>
+          <div class="publication-groups" data-js="publication-groups"></div>
+        </div>
+      </section>
+
+      <!-- ================ -->
+      <!-- Projects section -->
+      <!-- ================ -->
+      <section class="portfolio" id="projects">
+        <div class="container">
+          <h2 class="section-title">Flagship Projects</h2>
+          <p class="section-subtitle">
+            Systems I’ve led from concept to deployment—emphasising research-grade rigor, reliable autonomy, and measurable impact.
+          </p>
+          <div class="project-showcase" data-js="project-showcase"></div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- move the publications section ahead of projects and generate richer status cards for manuscripts
- redesign the projects area into a flagship case-study showcase with detailed highlights and tooling
- refresh supporting styles and scripts to drive the new layouts and intersection animations

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dff746e1f0832c999b3d53c5efa210