### PR TITLE
Revamp extracurriculars layout and contact CTA

### DIFF
--- a/assets/images/extracurriculars/aeromodelling.svg
+++ b/assets/images/extracurriculars/aeromodelling.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/images/extracurriculars/hackathon.svg
+++ b/assets/images/extracurriculars/hackathon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/images/extracurriculars/maximus.svg
+++ b/assets/images/extracurriculars/maximus.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/images/extracurriculars/robotics-outreach.svg
+++ b/assets/images/extracurriculars/robotics-outreach.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/images/extracurriculars/student-council.svg
+++ b/assets/images/extracurriculars/student-council.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/images/extracurriculars/synergy.svg
+++ b/assets/images/extracurriculars/synergy.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#121c3b" />
+      <stop offset="50%" stop-color="#273b75" />
+      <stop offset="100%" stop-color="#1b1033" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#grad)" />
+  <g fill="#ffffff" fill-opacity="0.85" font-family="'Space Grotesk', 'DM Sans', sans-serif" font-weight="600">
+    <text x="50%" y="52%" font-size="64" text-anchor="middle" letter-spacing="4">
+      Extracurricular Image
+    </text>
+  </g>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -953,131 +953,225 @@ body[data-theme='light'] .project-case__meta-block {
   }
 }
 
-/* ================== */
-/* Long-horizon cards */
-/* ================== */
-.long-horizon {
+/* ===================== */
+/* Extracurricular cards */
+/* ===================== */
+.extracurriculars {
+  background: linear-gradient(180deg, rgba(10, 16, 32, 0.8), rgba(6, 10, 24, 0.92));
+  border-block: 1px solid var(--color-border);
+  position: relative;
+  overflow: hidden;
+}
+
+.extracurriculars::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% -10%, rgba(123, 131, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 110%, rgba(111, 225, 255, 0.14), transparent 60%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.extracurriculars .container {
+  position: relative;
+  z-index: 1;
+}
+
+.extracurriculars__masonry {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.extracurricular-card {
+  --easing: cubic-bezier(0.22, 1, 0.36, 1);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
+  border-radius: calc(var(--radius-lg) + 4px);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  transform: translateY(32px);
+  opacity: 0;
+  animation: card-float 0.9s var(--easing) forwards;
+  animation-delay: calc(var(--index, 0) * 0.12s);
+}
+
+.extracurricular-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(8, 12, 24, 0) 40%, rgba(10, 14, 28, 0.4) 100%);
+  opacity: 0;
+  transition: opacity 250ms var(--easing);
+}
+
+.extracurricular-card__media {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+}
+
+.extracurricular-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(1.05);
+  transform: scale(1.05);
+  transition: transform 450ms var(--easing), filter 450ms var(--easing);
+}
+
+.extracurricular-card__body {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.extracurricular-card__tag {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-accent) 70%, var(--color-muted));
+}
+
+.extracurricular-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.15rem, 2.5vw, 1.45rem);
+  color: var(--color-heading);
+}
+
+.extracurricular-card__copy {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.extracurricular-card:hover::after,
+.extracurricular-card:focus-within::after {
+  opacity: 1;
+}
+
+.extracurricular-card:hover .extracurricular-card__media img,
+.extracurricular-card:focus-within .extracurricular-card__media img {
+  transform: scale(1.1);
+  filter: saturate(1.2);
+}
+
+@keyframes card-float {
+  0% {
+    transform: translateY(32px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .extracurriculars__masonry {
+    gap: 1.25rem;
+  }
+}
+
+/* ===================== */
+/* Contact mini section  */
+/* ===================== */
+.contact-mini {
   background: var(--color-section);
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 }
 
-.long-horizon__grid {
+.contact-mini__inner {
   display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: center;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
-.long-horizon-card {
-  background: var(--color-surface);
+.contact-mini__copy .section-title,
+.contact-mini__copy .section-subtitle {
+  text-align: left;
+  margin-left: 0;
+}
+
+.contact-mini__actions {
+  display: grid;
+  gap: 1rem;
+  justify-items: start;
+}
+
+.contact-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1.15rem;
+  border-radius: 1rem;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.1rem;
-  display: grid;
-  gap: 0.75rem;
-  box-shadow: var(--shadow-soft);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
 
-.long-horizon-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.long-horizon-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.long-horizon-card a {
+.contact-chip__label {
+  font-size: 0.75rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--color-muted) 80%, var(--color-heading));
+}
+
+.contact-chip__value {
+  font-size: 1.05rem;
+  color: var(--color-heading);
+  font-weight: 600;
+}
+
+.contact-chip:hover,
+.contact-chip:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+  border-color: var(--color-accent);
+}
+
+.contact-mini__links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.contact-mini__links a {
+  color: var(--color-heading);
+  font-weight: 600;
+}
+
+.contact-mini__links a:hover,
+.contact-mini__links a:focus-visible {
   color: var(--color-accent);
 }
 
-/* ================ */
-/* Resources & Bib  */
-/* ================ */
-.resources {
-  padding: 3rem 0;
-  background: rgba(3, 7, 16, 0.6);
-  border-block: 1px solid var(--color-border);
-}
+@media (max-width: 960px) {
+  .contact-mini__inner {
+    grid-template-columns: 1fr;
+  }
 
-.resources .section-subtitle {
-  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
-}
+  .contact-mini__copy .section-title,
+  .contact-mini__copy .section-subtitle {
+    text-align: center;
+  }
 
-.resource-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.resource-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 1.75rem;
-  display: grid;
-  gap: 1rem;
-  box-shadow: var(--shadow-soft);
-}
-
-.resource-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.resource-card p {
-  margin: 0;
-  color: var(--color-muted);
-}
-
-.resource-card .button {
-  justify-content: center;
-  margin-top: 0.5rem;
-}
-
-.bibtex {
-  background: var(--color-section);
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.bibtex__content {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.75rem;
-  margin-top: 2.5rem;
-}
-
-.contact-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
-  padding: 1.5rem;
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.contact-card h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  color: var(--color-heading);
-}
-
-.contact-card p,
-.contact-card ul {
-  margin: 0;
-  color: var(--color-muted);
-  padding: 0;
-  list-style: none;
-}
-
-contact-card ul li + li {
-  margin-top: 0.35rem;
+  .contact-mini__actions {
+    justify-items: center;
+  }
 }
 
 /* ============== */

--- a/index.html
+++ b/index.html
@@ -48,8 +48,7 @@
           <a href="#research">Research</a>
           <a href="#publications">Publications</a>
           <a href="#projects">Projects</a>
-          <a href="#media">Media</a>
-          <a href="#resources">Resources</a>
+          <a href="#extracurriculars">Extracurriculars</a>
           <a href="#contact">Contact</a>
         </nav>
 
@@ -161,53 +160,84 @@
       <!-- ============== -->
       <!-- Media section -->
       <!-- ============== -->
-      <section class="long-horizon" id="media">
+      <section class="extracurriculars" id="extracurriculars">
         <div class="container">
-          <h2 class="section-title">Extracurriculars</h2>
+          <h2 class="section-title">Extracurricular Highlights</h2>
           <p class="section-subtitle">
-            Leadership roles and community involvement.
+            A snapshot of communities I've helped grow—from technical clubs to institute-level festivals.
           </p>
-          <div class="long-horizon__grid">
-            <article class="long-horizon-card">
-              <h3>Third Dimension Aeromodelling Club</h3>
-              <p>Technical Mentor (Mar 2024 – Present)</p>
+          <div class="extracurriculars__masonry">
+            <article class="extracurricular-card" style="--index: 0">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/aeromodelling.svg" alt="Students building an RC aircraft" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Technical Mentor · 2024 – Present</p>
+                <h3 class="extracurricular-card__title">Third Dimension Aeromodelling Club</h3>
+                <p class="extracurricular-card__copy">
+                  Lead design sprints, train junior teams on fixed-wing autonomy, and oversee intercollegiate racing campaigns.
+                </p>
+              </div>
             </article>
-            <article class="long-horizon-card">
-              <h3>Maximus – Math & Physics Society</h3>
-              <p>Vice President (May 2025 – Present)</p>
+            <article class="extracurricular-card" style="--index: 1">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/maximus.svg" alt="Students solving math puzzles together" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Vice President · 2025 – Present</p>
+                <h3 class="extracurricular-card__title">Maximus – Math &amp; Physics Society</h3>
+                <p class="extracurricular-card__copy">
+                  Curated research colloquia, mentored Olympiad hopefuls, and reimagined flagship puzzle hunts with 500+ participants.
+                </p>
+              </div>
             </article>
-            <article class="long-horizon-card">
-              <h3>Synergy, Mechanical Symposium</h3>
-              <p>Head of Workshops (Nov 2023 – Present)</p>
+            <article class="extracurricular-card" style="--index: 2">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/synergy.svg" alt="Workshop audience at a mechanical engineering symposium" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Head of Workshops · 2023 – Present</p>
+                <h3 class="extracurricular-card__title">Synergy, Mechanical Symposium</h3>
+                <p class="extracurricular-card__copy">
+                  Built hands-on labs for 1k+ attendees, orchestrating industry speakers and prototyping stations under tight timelines.
+                </p>
+              </div>
             </article>
-          </div>
-        </div>
-      </section>
-
-      <!-- ================= -->
-      <!-- Resources section -->
-      <!-- ================= -->
-      <section class="resources" id="resources">
-        <div class="container">
-          <h2 class="section-title">Resources</h2>
-          <p class="section-subtitle">
-            I'm committed to sharing tools and datasets that help others accelerate progress in robotics.
-          </p>
-          <div class="resource-grid">
-            <article class="resource-card">
-              <h3>Code Repositories</h3>
-              <p>Open-sourced frameworks for hierarchical RL, simulation pipelines, and evaluation tooling.</p>
-              <a href="https://github.com/Narendhiranv04?tab=repositories" target="_blank" rel="noopener">Explore GitHub</a>
+            <article class="extracurricular-card" style="--index: 3">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/robotics-outreach.svg" alt="High school students trying a robot demo" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Lead Instructor · 2024</p>
+                <h3 class="extracurricular-card__title">STEM Outreach Program</h3>
+                <p class="extracurricular-card__copy">
+                  Designed weekend robotics bootcamps for local schools, blending hardware demos with creative coding challenges.
+                </p>
+              </div>
             </article>
-            <article class="resource-card">
-              <h3>Datasets</h3>
-              <p>Curated manipulation datasets with language annotations for compositional skill learning.</p>
-              <a href="#" target="_blank" rel="noopener">Download (coming soon)</a>
+            <article class="extracurricular-card" style="--index: 4">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/hackathon.svg" alt="Hackathon participants collaborating" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Organiser · 2023 – 2024</p>
+                <h3 class="extracurricular-card__title">NIT Trichy Make-a-thon</h3>
+                <p class="extracurricular-card__copy">
+                  Co-led a 36-hour product buildathon, integrating rapid prototyping labs and mentorship pods across 60+ teams.
+                </p>
+              </div>
             </article>
-            <article class="resource-card">
-              <h3>Teaching Materials</h3>
-              <p>Workshops and lecture notes on embodied AI, reinforcement learning, and robot safety.</p>
-              <a href="#" target="_blank" rel="noopener">View Slides</a>
+            <article class="extracurricular-card" style="--index: 5">
+              <figure class="extracurricular-card__media">
+                <img src="assets/images/extracurriculars/student-council.svg" alt="Student council members celebrating" />
+              </figure>
+              <div class="extracurricular-card__body">
+                <p class="extracurricular-card__tag">Coordinator · 2022 – 2023</p>
+                <h3 class="extracurricular-card__title">Institute Student Council</h3>
+                <p class="extracurricular-card__copy">
+                  Managed cross-club logistics, championed student welfare initiatives, and launched a mentorship pipeline for freshmen.
+                </p>
+              </div>
             </article>
           </div>
         </div>
@@ -216,28 +246,27 @@
       <!-- ============== -->
       <!-- Contact section -->
       <!-- ============== -->
-      <section class="bibtex" id="contact">
-        <div class="container">
-          <h2 class="section-title">Get in Touch</h2>
-          <p class="section-subtitle">
-            I'm always happy to chat about research collaborations, student mentorship, or speaking
-            opportunities. Send me a note and I'll get back to you shortly.
-          </p>
-          <div class="bibtex__content">
-            <div class="contact-card">
-              <h3>Email</h3>
-              <p><a href="mailto:narendhiranv.nitt@gmail.com">narendhiranv.nitt@gmail.com</a></p>
-            </div>
-            <div class="contact-card">
-              <h3>Phone</h3>
-              <p>(+91) 94447-49184</p>
-            </div>
-            <div class="contact-card">
-              <h3>Elsewhere</h3>
-              <ul>
-                <li><a href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">GitHub</a></li>
-                <li><a href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">LinkedIn</a></li>
-              </ul>
+      <section class="contact-mini" id="contact">
+        <div class="container contact-mini__inner">
+          <div class="contact-mini__copy">
+            <h2 class="section-title">Let's Collaborate</h2>
+            <p class="section-subtitle">
+              Building something in robotics or looking for a workshop speaker? Drop me a note and I'll respond within a couple of days.
+            </p>
+          </div>
+          <div class="contact-mini__actions">
+            <a class="contact-chip" href="mailto:narendhiranv.nitt@gmail.com">
+              <span class="contact-chip__label">Email</span>
+              <span class="contact-chip__value">narendhiranv.nitt@gmail.com</span>
+            </a>
+            <a class="contact-chip" href="tel:+919444749184">
+              <span class="contact-chip__label">Phone</span>
+              <span class="contact-chip__value">(+91) 94447-49184</span>
+            </a>
+            <div class="contact-mini__links">
+              <a href="https://github.com/Narendhiranv04" target="_blank" rel="noopener">GitHub</a>
+              <span aria-hidden="true">•</span>
+              <a href="https://www.linkedin.com/in/narendhiranv04" target="_blank" rel="noopener">LinkedIn</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- redesign the extracurriculars section with six image-forward cards and scroll animation
- remove the old resources block and introduce a compact contact call-to-action
- add placeholder artwork for extracurricular entries so images can be swapped in easily

## Testing
- no automated tests were run (not applicable for static content)


------
https://chatgpt.com/codex/tasks/task_e_68dffcdd8838832c803b9620e69ef991