### PR TITLE
Refresh projects and extracurricular layouts

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -505,11 +505,10 @@ const flagshipProjects = [
     timeframe: 'SAE AeroTHON · 2024',
     description:
       'Led the systems team delivering a competition-ready quadcopter with full autonomy stack, resilient perception, and safety interlocks.',
-    highlights: [
-      'Modular ROS 2 stack spanning mission planning, guidance, and PX4-based control.',
-      'Vision-driven landing pipeline with adaptive AprilTag filtering for gusty outdoor runs.',
-      'Mission rehearsals validated autonomous sorties under changing payload configurations.',
-    ],
+    image: {
+      src: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Autonomous quadcopter flying over a field',
+    },
     technologies: ['ROS 2', 'PX4 Autopilot', 'OpenCV', 'NVIDIA Jetson'],
     outcome:
       'Top-15 national finish with sustained autonomous flight across endurance, payload drop, and navigation tasks.',
@@ -520,11 +519,10 @@ const flagshipProjects = [
     timeframe: 'Smart India Hackathon · 2024',
     description:
       'Built a co-pilot for image-centric workflows that blends grounded visual question answering with controllable generative edits.',
-    highlights: [
-      'Staged reasoning harnessing LLaVA for analysis, SAM2 for masks, and GLIGEN for guided synthesis.',
-      'Pipeline orchestration with async task queue delivering responses under 4 seconds per request.',
-      'Evaluation harness with curated benchmarks for instruction-following and edit fidelity.',
-    ],
+    image: {
+      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Robotic arm interacting with a visual interface',
+    },
     technologies: ['Python', 'LLaVA', 'SAM2', 'FastAPI', 'Redis'],
     outcome:
       'Secured 2nd place in the national qualifier while open-sourcing reusable evaluation utilities.',
@@ -535,11 +533,10 @@ const flagshipProjects = [
     timeframe: 'MathWorks Minidrone Challenge · 2023',
     description:
       'Engineered a lightweight autonomy stack for the Parrot Mambo microdrone using MATLAB/Simulink for rapid iteration.',
-    highlights: [
-      'Stateflow-based mission planner with guard conditions for dynamic gate ordering.',
-      'Custom lane-detection vision filters running at 60 FPS on-board the drone.',
-      'Hardware-in-the-loop validation that reduced oscillations during tight turns.',
-    ],
+    image: {
+      src: 'https://images.unsplash.com/photo-1508610048659-a06b669e3321?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Micro drone flying through an illuminated course',
+    },
     technologies: ['MATLAB', 'Simulink', 'Stateflow', 'Embedded Coder'],
     outcome:
       'Achieved fully autonomous line-following with reliable gate traversal in final demos.',
@@ -550,11 +547,10 @@ const flagshipProjects = [
     timeframe: 'March 2024',
     description:
       'Developed a Python toolkit for navigation on dense occupancy grids with occlusion-aware path reasoning.',
-    highlights: [
-      'Tangent-arc computation with masked visibility cones to negotiate cluttered spaces.',
-      'Parameterised curvature profiles enabling smooth transitions from 90° start orientations.',
-      'Interactive visualiser for debugging candidate paths and clearance margins.',
-    ],
+    image: {
+      src: 'https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Path planning visualization on a grid map',
+    },
     technologies: ['Python', 'NumPy', 'Shapely', 'Matplotlib'],
     outcome:
       'Adopted in internal autonomy experiments for rapid what-if analysis of navigation policies.',
@@ -568,6 +564,18 @@ if (projectShowcase) {
     const article = document.createElement('article');
     article.className = 'project-case';
     article.style.setProperty('--animation-index', index.toString());
+
+    if (project.image?.src) {
+      const media = document.createElement('figure');
+      media.className = 'project-case__media';
+
+      const img = document.createElement('img');
+      img.src = project.image.src;
+      img.alt = project.image.alt || `${project.title} illustration`;
+
+      media.appendChild(img);
+      article.appendChild(media);
+    }
 
     const summary = document.createElement('div');
     summary.className = 'project-case__summary';
@@ -585,19 +593,6 @@ if (projectShowcase) {
     description.textContent = project.description;
 
     summary.append(eyebrow, title, description);
-
-    if (Array.isArray(project.highlights) && project.highlights.length) {
-      const highlightList = document.createElement('ul');
-      highlightList.className = 'project-case__highlights';
-
-      project.highlights.forEach((highlight) => {
-        const li = document.createElement('li');
-        li.textContent = highlight;
-        highlightList.appendChild(li);
-      });
-
-      summary.appendChild(highlightList);
-    }
 
     const details = document.createElement('div');
     details.className = 'project-case__details';
@@ -653,7 +648,11 @@ if (projectShowcase) {
       details.appendChild(outcomeBlock);
     }
 
-    article.append(summary, details);
+    const content = document.createElement('div');
+    content.className = 'project-case__content';
+    content.append(summary, details);
+
+    article.appendChild(content);
     projectShowcase.appendChild(article);
   });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -769,21 +769,23 @@ body[data-theme='light'] .publication-card {
   gap: clamp(1.75rem, 4vw, 2.5rem);
 }
 
+
 .project-case {
   position: relative;
   overflow: hidden;
   display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
-  gap: clamp(1.5rem, 4vw, 2.75rem);
-  padding: clamp(2rem, 4.5vw, 2.85rem);
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  align-items: stretch;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
+  padding: clamp(2rem, 4.5vw, 3rem);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
   background: linear-gradient(
       135deg,
-      rgba(123, 131, 255, 0.18),
-      transparent 55%
+      color-mix(in srgb, var(--color-surface) 85%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt) 75%, transparent) 100%
     ),
-    var(--color-surface);
+    color-mix(in srgb, var(--color-bg) 45%, rgba(123, 131, 255, 0.12));
   box-shadow: var(--shadow-soft);
   transform: translateY(48px);
   opacity: 0;
@@ -795,13 +797,14 @@ body[data-theme='light'] .publication-card {
 .project-case::before {
   content: '';
   position: absolute;
-  inset: -35% -20% 40% 45%;
+  inset: -20% 15% 55% -25%;
   background: radial-gradient(
-    circle at top,
-    rgba(123, 131, 255, 0.4),
-    transparent 65%
-  );
-  opacity: 0.55;
+      circle at top left,
+      rgba(123, 131, 255, 0.28),
+      transparent 65%
+    ),
+    radial-gradient(circle at bottom right, rgba(111, 225, 255, 0.18), transparent 70%);
+  opacity: 0.45;
   pointer-events: none;
 }
 
@@ -813,6 +816,36 @@ body[data-theme='light'] .publication-card {
 .project-case.is-visible {
   transform: translateY(0);
   opacity: 1;
+}
+
+.project-case__media {
+  position: relative;
+  border-radius: calc(var(--radius-lg) - 8px);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 45%, transparent);
+}
+
+.project-case__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(8, 12, 24, 0) 45%, rgba(8, 12, 24, 0.35) 100%);
+  mix-blend-mode: soft-light;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.project-case__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-case__content {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.35rem);
+  align-content: stretch;
 }
 
 .project-case__summary {
@@ -843,36 +876,11 @@ body[data-theme='light'] .publication-card {
   max-width: 58ch;
 }
 
-.project-case__highlights {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.65rem;
-}
-
-.project-case__highlights li {
-  margin: 0;
-  padding-left: 1.35rem;
-  position: relative;
-  color: var(--color-muted);
-  font-size: 0.97rem;
-  line-height: 1.6;
-}
-
-.project-case__highlights li::before {
-  content: '✶';
-  position: absolute;
-  left: 0;
-  color: var(--color-accent);
-  font-size: 0.8rem;
-  top: 0.35rem;
-}
-
 .project-case__details {
   display: grid;
   gap: 1rem;
   align-content: start;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .project-case__meta-block {
@@ -925,19 +933,33 @@ body[data-theme='light'] .project-case__meta-block {
   font-weight: 600;
 }
 
+@media (max-width: 1100px) {
+  .project-case {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 960px) {
   .project-case {
     grid-template-columns: 1fr;
   }
 
-  .project-case__details {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  .project-case__media {
+    height: clamp(240px, 48vw, 360px);
+  }
+
+  .project-case__content {
+    gap: clamp(1.2rem, 5vw, 2rem);
   }
 }
 
 @media (max-width: 640px) {
   .project-case__details {
     grid-template-columns: 1fr;
+  }
+
+  .project-case__media {
+    height: clamp(200px, 52vw, 260px);
   }
 
   .project-case__meta-block {
@@ -956,9 +978,14 @@ body[data-theme='light'] .project-case__meta-block {
 /* ===================== */
 /* Extracurricular cards */
 /* ===================== */
+
 .extracurriculars {
-  background: linear-gradient(180deg, rgba(10, 16, 32, 0.8), rgba(6, 10, 24, 0.92));
-  border-block: 1px solid var(--color-border);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-section) 70%, rgba(123, 131, 255, 0.2)) 0%,
+    color-mix(in srgb, var(--color-section) 55%, rgba(111, 225, 255, 0.18)) 100%
+  );
+  border-block: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
   position: relative;
   overflow: hidden;
 }
@@ -967,10 +994,10 @@ body[data-theme='light'] .project-case__meta-block {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% -10%, rgba(123, 131, 255, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 110%, rgba(111, 225, 255, 0.14), transparent 60%);
+  background: radial-gradient(circle at 12% -8%, rgba(123, 131, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 82% 105%, rgba(111, 225, 255, 0.22), transparent 60%);
   pointer-events: none;
-  mix-blend-mode: screen;
+  mix-blend-mode: soft-light;
 }
 
 .extracurriculars .container {
@@ -978,26 +1005,30 @@ body[data-theme='light'] .project-case__meta-block {
   z-index: 1;
 }
 
+
 .extracurriculars__masonry {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: clamp(1.5rem, 4vw, 2.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(460px, 1fr));
+  gap: clamp(1.75rem, 4vw, 2.75rem);
 }
 
 .extracurricular-card {
   --easing: cubic-bezier(0.22, 1, 0.36, 1);
   position: relative;
   display: flex;
-  flex-direction: column;
-  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
-  border-radius: calc(var(--radius-lg) + 4px);
-  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  flex-direction: row;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  background: color-mix(in srgb, var(--color-surface) 90%, rgba(255, 255, 255, 0.05));
+  border-radius: calc(var(--radius-lg) + 6px);
+  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
   box-shadow: var(--shadow-soft);
+  padding: clamp(1.5rem, 3.5vw, 2.25rem);
   overflow: hidden;
   transform: translateY(32px);
   opacity: 0;
   animation: card-float 0.9s var(--easing) forwards;
   animation-delay: calc(var(--index, 0) * 0.12s);
+  backdrop-filter: blur(14px);
 }
 
 .extracurricular-card::after {
@@ -1005,30 +1036,32 @@ body[data-theme='light'] .project-case__meta-block {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(180deg, rgba(8, 12, 24, 0) 40%, rgba(10, 14, 28, 0.4) 100%);
+  background: linear-gradient(120deg, rgba(123, 131, 255, 0.12), rgba(8, 12, 24, 0.22));
   opacity: 0;
   transition: opacity 250ms var(--easing);
 }
 
 .extracurricular-card__media {
   position: relative;
-  aspect-ratio: 16 / 10;
+  flex: 0 0 clamp(220px, 28vw, 320px);
+  border-radius: calc(var(--radius-lg) - 2px);
   overflow: hidden;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);
 }
 
 .extracurricular-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(1.05);
-  transform: scale(1.05);
+  filter: saturate(1.08);
+  transform: scale(1.02);
   transition: transform 450ms var(--easing), filter 450ms var(--easing);
 }
 
 .extracurricular-card__body {
   display: grid;
-  gap: 0.75rem;
-  padding: clamp(1.25rem, 3vw, 1.75rem);
+  gap: clamp(0.85rem, 2vw, 1.25rem);
+  align-content: center;
 }
 
 .extracurricular-card__tag {
@@ -1059,8 +1092,8 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurricular-card:hover .extracurricular-card__media img,
 .extracurricular-card:focus-within .extracurricular-card__media img {
-  transform: scale(1.1);
-  filter: saturate(1.2);
+  transform: scale(1.08);
+  filter: saturate(1.18);
 }
 
 @keyframes card-float {
@@ -1074,9 +1107,30 @@ body[data-theme='light'] .project-case__meta-block {
   }
 }
 
+@media (max-width: 960px) {
+  .extracurriculars__masonry {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .extracurricular-card {
+    flex-direction: column;
+    padding: clamp(1.35rem, 4vw, 1.85rem);
+  }
+
+  .extracurricular-card__media {
+    width: 100%;
+    flex: none;
+    aspect-ratio: 16 / 10;
+  }
+}
+
 @media (max-width: 640px) {
   .extracurriculars__masonry {
-    gap: 1.25rem;
+    gap: 1.35rem;
+  }
+
+  .extracurricular-card__body {
+    gap: 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyled the extracurricular section with brighter gradients and wide side-by-side cards
- reworked flagship project cards to feature large imagery alongside details instead of bullet highlights

## Testing
- python3 -m http.server 8000 (manual visual check)


------
https://chatgpt.com/codex/tasks/task_e_68e0051e5f58832c90d2815f78f184f1