### PR TITLE
Adjust project and extracurricular layouts

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -825,6 +825,14 @@ body[data-theme='light'] .publication-card {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 45%, transparent);
 }
 
+@media (min-width: 961px) {
+  .project-case__media {
+    aspect-ratio: 1 / 1;
+    max-height: 360px;
+    align-self: start;
+  }
+}
+
 .project-case__media::after {
   content: '';
   position: absolute;
@@ -880,7 +888,14 @@ body[data-theme='light'] .publication-card {
   display: grid;
   gap: 1rem;
   align-content: start;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: stretch;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 1100px) {
+  .project-case__details {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .project-case__meta-block {
@@ -890,6 +905,7 @@ body[data-theme='light'] .publication-card {
   border-radius: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(9, 14, 28, 0.55);
+  align-content: start;
 }
 
 body[data-theme='light'] .project-case__meta-block {
@@ -1008,8 +1024,14 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurriculars__masonry {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(460px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+@media (max-width: 1200px) {
+  .extracurriculars__masonry {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .extracurricular-card {
@@ -1043,7 +1065,7 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurricular-card__media {
   position: relative;
-  flex: 0 0 clamp(220px, 28vw, 320px);
+  flex: 0 0 clamp(160px, 22vw, 220px);
   border-radius: calc(var(--radius-lg) - 2px);
   overflow: hidden;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);


### PR DESCRIPTION
## Summary
- square up project imagery on large screens and lay out the stage/stack/outcome blocks in a horizontal row
- expand the extracurricular highlight grid into three columns with narrower artwork so the section fills the page width

## Testing
- No automated tests (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e009794864832caf148cfc0e345ac3