### PR TITLE
Refine project highlights layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -774,19 +774,18 @@ body[data-theme='light'] .publication-card {
   position: relative;
   overflow: hidden;
   display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
   align-items: stretch;
-  gap: clamp(1.75rem, 4vw, 2.75rem);
-  padding: clamp(2rem, 4.5vw, 3rem);
+  gap: clamp(1.5rem, 4vw, 2.25rem);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
   border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
-  background: linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--color-surface) 85%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-alt) 75%, transparent) 100%
-    ),
-    color-mix(in srgb, var(--color-bg) 45%, rgba(123, 131, 255, 0.12));
-  box-shadow: var(--shadow-soft);
+  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  background: color-mix(
+      in srgb,
+      var(--color-surface) 72%,
+      rgba(255, 255, 255, 0.58)
+    );
+  box-shadow: var(--shadow-sm);
   transform: translateY(48px);
   opacity: 0;
   transition: transform 0.6s cubic-bezier(0.21, 0.78, 0.35, 1),
@@ -822,15 +821,10 @@ body[data-theme='light'] .publication-card {
   position: relative;
   border-radius: calc(var(--radius-lg) - 8px);
   overflow: hidden;
+  aspect-ratio: 4 / 3;
+  max-height: 320px;
+  align-self: start;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 45%, transparent);
-}
-
-@media (min-width: 961px) {
-  .project-case__media {
-    aspect-ratio: 1 / 1;
-    max-height: 360px;
-    align-self: start;
-  }
 }
 
 .project-case__media::after {
@@ -886,36 +880,31 @@ body[data-theme='light'] .publication-card {
 
 .project-case__details {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   align-content: start;
   align-items: stretch;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-@media (max-width: 1100px) {
-  .project-case__details {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .project-case__meta-block {
   display: grid;
-  gap: 0.35rem;
-  padding: 1rem 1.1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(9, 14, 28, 0.55);
-  align-content: start;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 75%, rgba(255, 255, 255, 0.35));
+  align-items: start;
 }
 
 body[data-theme='light'] .project-case__meta-block {
-  background: rgba(255, 255, 255, 0.82);
-  border-color: rgba(49, 46, 129, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(49, 46, 129, 0.18);
 }
 
 .project-case__meta-block--accent {
-  background: rgba(123, 131, 255, 0.22);
-  border-color: rgba(123, 131, 255, 0.45);
+  background: color-mix(in srgb, rgba(123, 131, 255, 0.32) 70%, rgba(255, 255, 255, 0.58));
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
 }
 
 .project-case__meta-label {
@@ -923,10 +912,12 @@ body[data-theme='light'] .project-case__meta-block {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
+  white-space: nowrap;
+  align-self: center;
 }
 
 .project-case__meta-value {
-  font-size: 0.98rem;
+  font-size: 0.96rem;
   font-weight: 600;
   color: var(--color-heading);
 }
@@ -937,7 +928,8 @@ body[data-theme='light'] .project-case__meta-block {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  justify-content: flex-start;
 }
 
 .project-case__tech-list li {
@@ -961,7 +953,8 @@ body[data-theme='light'] .project-case__meta-block {
   }
 
   .project-case__media {
-    height: clamp(240px, 48vw, 360px);
+    width: 100%;
+    max-height: none;
   }
 
   .project-case__content {
@@ -975,7 +968,7 @@ body[data-theme='light'] .project-case__meta-block {
   }
 
   .project-case__media {
-    height: clamp(200px, 52vw, 260px);
+    width: 100%;
   }
 
   .project-case__meta-block {
@@ -1065,9 +1058,10 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurricular-card__media {
   position: relative;
-  flex: 0 0 clamp(160px, 22vw, 220px);
+  flex: 0 0 clamp(150px, 21vw, 210px);
   border-radius: calc(var(--radius-lg) - 2px);
   overflow: hidden;
+  aspect-ratio: 1 / 1;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);
 }
 
@@ -1142,7 +1136,7 @@ body[data-theme='light'] .project-case__meta-block {
   .extracurricular-card__media {
     width: 100%;
     flex: none;
-    aspect-ratio: 16 / 10;
+    aspect-ratio: 1 / 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyle flagship project cards with lighter surfaces, a slimmer footprint, and horizontal Stage/Stack/Outcome rows
- adjust project metadata blocks for row-based label/value layout while keeping tech chips aligned
- enforce square art for extracurricular highlights for consistent visual rhythm

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e020ff58b8832c8c3de89409674bec