### PR TITLE
Tighten extracurricular image layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1067,16 +1067,18 @@ body[data-theme='light'] .project-case__meta-block {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: clamp(0.65rem, 2vw, 1rem);
 }
 
 .extracurricular-card__media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: clamp(70%, 82%, 88%);
+  max-height: 100%;
+  object-fit: contain;
   object-position: center;
   filter: saturate(1.08);
-  transform: scale(1.02);
+  transform: scale(0.88);
   transition: transform 450ms var(--easing), filter 450ms var(--easing);
+  margin: 0 auto;
 }
 
 .extracurricular-card__body {
@@ -1113,7 +1115,7 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurricular-card:hover .extracurricular-card__media img,
 .extracurricular-card:focus-within .extracurricular-card__media img {
-  transform: scale(1.08);
+  transform: scale(0.98);
   filter: saturate(1.18);
 }
 


### PR DESCRIPTION
## Summary
- add inner padding to extracurricular card media frames so artwork has breathing room
- scale SVGs down slightly and center them with contain fit to align consistently across cards
- adjust hover scaling to match the reduced base size without overshooting the frame

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e02b5abba0832c91e08d4172277869