### PR TITLE
Refine extracurricular card imagery

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1064,19 +1064,19 @@ body[data-theme='light'] .project-case__meta-block {
   aspect-ratio: 4 / 3;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);
   margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  place-items: center;
+  padding: clamp(0.85rem, 2.6vw, 1.25rem);
 }
 
 .extracurricular-card__media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: clamp(120px, 58%, 210px);
+  max-height: calc(100% - clamp(0.5rem, 1.5vw, 0.75rem));
+  object-fit: contain;
   object-position: center;
   filter: saturate(1.08);
-  transform: scale(1.02);
   transition: transform 450ms var(--easing), filter 450ms var(--easing);
+  transform: translateZ(0);
 }
 
 .extracurricular-card__body {
@@ -1113,7 +1113,7 @@ body[data-theme='light'] .project-case__meta-block {
 
 .extracurricular-card:hover .extracurricular-card__media img,
 .extracurricular-card:focus-within .extracurricular-card__media img {
-  transform: scale(1.08);
+  transform: scale(1.04);
   filter: saturate(1.18);
 }
 


### PR DESCRIPTION
## Summary
- switch extracurricular media frames to a centered grid layout so assets snap to a consistent focal point
- cap artwork width with responsive clamps to keep each illustration proportionally scaled inside its frame
- refresh hover scaling to grow from the new resting size without misalignment

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e02b5abba0832c91e08d4172277869