### PR TITLE
Reset extracurricular media margins

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1063,7 +1063,7 @@ body[data-theme='light'] .project-case__meta-block {
   overflow: hidden;
   aspect-ratio: 4 / 3;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border) 40%, transparent);
-  margin-bottom: clamp(1.25rem, 3vw, 1.75rem);
+  margin: 0 0 clamp(1.25rem, 3vw, 1.75rem);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- reset the `.extracurricular-card__media` margins so the figure is flush with the card padding while retaining bottom spacing

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e031a17f7c832c8a87bd5c975609ed