### PR TITLE
Update imagery assets for profile, projects, and extracurriculars

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -506,8 +506,8 @@ const flagshipProjects = [
     description:
       'Led the systems team delivering a competition-ready quadcopter with full autonomy stack, resilient perception, and safety interlocks.',
     image: {
-      src: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Autonomous quadcopter flying over a field',
+      src: 'uav.jpg',
+      alt: 'Autonomous quadcopter at the SAE AeroTHON',
     },
     technologies: ['ROS 2', 'PX4 Autopilot', 'OpenCV', 'NVIDIA Jetson'],
     outcome:
@@ -520,8 +520,8 @@ const flagshipProjects = [
     description:
       'Built a co-pilot for image-centric workflows that blends grounded visual question answering with controllable generative edits.',
     image: {
-      src: 'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Robotic arm interacting with a visual interface',
+      src: 'pixelbot.jpg',
+      alt: 'PixelBot multimodal assistant interface mockup',
     },
     technologies: ['Python', 'LLaVA', 'SAM2', 'FastAPI', 'Redis'],
     outcome:
@@ -534,8 +534,8 @@ const flagshipProjects = [
     description:
       'Engineered a lightweight autonomy stack for the Parrot Mambo microdrone using MATLAB/Simulink for rapid iteration.',
     image: {
-      src: 'https://images.unsplash.com/photo-1508610048659-a06b669e3321?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Micro drone flying through an illuminated course',
+      src: 'mathworks.jpg',
+      alt: 'Parrot Mambo drone on display at the MathWorks challenge',
     },
     technologies: ['MATLAB', 'Simulink', 'Stateflow', 'Embedded Coder'],
     outcome:
@@ -548,8 +548,8 @@ const flagshipProjects = [
     description:
       'Developed a Python toolkit for navigation on dense occupancy grids with occlusion-aware path reasoning.',
     image: {
-      src: 'https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Path planning visualization on a grid map',
+      src: 'randomized_triangle_2.jpeg',
+      alt: 'Occlusion-aware navigation heatmap visualization',
     },
     technologies: ['Python', 'NumPy', 'Shapely', 'Matplotlib'],
     outcome:

--- a/assets/style.css
+++ b/assets/style.css
@@ -1079,6 +1079,7 @@ body[data-theme='light'] .project-case__meta-block {
   transform: scale(0.88);
   transition: transform 450ms var(--easing), filter 450ms var(--easing);
   margin: 0 auto;
+  border-radius: clamp(12px, 2vw, 18px);
 }
 
 .extracurricular-card__body {

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
           <div class="hero__media hero__visual">
             <div class="profile-card">
               <img
-                src="https://avatars.githubusercontent.com/u/71504281?v=4"
+                src="myself.jpg"
                 alt="Portrait of Narendhiran Vijayakumar"
                 class="profile-card__image"
               />
@@ -170,7 +170,7 @@
           <div class="extracurriculars__masonry">
             <article class="extracurricular-card" style="--index: 0">
               <figure class="extracurricular-card__media">
-                <img src="assets/images/extracurriculars/aeromodelling.svg" alt="Students building an RC aircraft" />
+                <img src="3d.jpg" alt="Students building an RC aircraft" />
               </figure>
               <div class="extracurricular-card__body">
                 <p class="extracurricular-card__tag">Technical Mentor · 2024 – Present</p>
@@ -182,7 +182,7 @@
             </article>
             <article class="extracurricular-card" style="--index: 1">
               <figure class="extracurricular-card__media">
-                <img src="assets/images/extracurriculars/maximus.svg" alt="Students solving math puzzles together" />
+                <img src="maximus.jpg" alt="Students solving math puzzles together" />
               </figure>
               <div class="extracurricular-card__body">
                 <p class="extracurricular-card__tag">Vice President · 2025 – Present</p>
@@ -194,7 +194,7 @@
             </article>
             <article class="extracurricular-card" style="--index: 2">
               <figure class="extracurricular-card__media">
-                <img src="assets/images/extracurriculars/synergy.svg" alt="Workshop audience at a mechanical engineering symposium" />
+                <img src="synergy.jpg" alt="Workshop audience at a mechanical engineering symposium" />
               </figure>
               <div class="extracurricular-card__body">
                 <p class="extracurricular-card__tag">Head of Workshops · 2023 – Present</p>
@@ -206,7 +206,7 @@
             </article>
             <article class="extracurricular-card" style="--index: 3">
               <figure class="extracurricular-card__media">
-                <img src="assets/images/extracurriculars/robotics-outreach.svg" alt="High school students trying a robot demo" />
+                <img src="ignitte.jpg" alt="High school students trying a robot demo" />
               </figure>
               <div class="extracurricular-card__body">
                 <p class="extracurricular-card__tag">Lead Instructor · 2024</p>


### PR DESCRIPTION
## Summary
- replace the hero profile photo and extracurricular gallery artwork with the uploaded images
- point flagship project cards to the newly provided local assets
- soften extracurricular imagery by adding gentle corner rounding to match the rest of the site

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e0368e69e0832c9ce62f8b6700fd4c