### PR TITLE
Inline research timeline logos

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -199,6 +199,15 @@ if ('IntersectionObserver' in window && sections.length) {
 }
 
 // --- RESEARCH TIMELINE ---
+const timelineLogos = {
+  ntu:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAIAAAC2BqGFAAACJUlEQVR4nO3cMWsTYRyA8f+ZoJCSyQrtEjq1fgQbQ+smAbcufgahg9Ch4NBVIZCPYYZ2LtklhE4hixmEgi6WdguENDReh0BxaSESnzvj85vu3nuHPw8vx02XfF3fCP19j7Ie4H9haIihIYaGGBpiaIihIYaGGBpiaIihIYaGGBpiaIihIYaGGBpiaIihIYaGGBpiaIihIYaGGBpiaIihIYaG5Df01vmgcvz57nZz0I+Icv115aRVOWk9//FtdlF+U589+n1bDhWzHuBe6fUkKRZL1RejTvducXjaHp62I2Jz0P++93a2uN74lM2I88jviY6Iy0Zz9eB91lMsRq5Dj750IqL0cjvrQRYg16Ej4mpZDnXeQ4863ZhOS7XqA3vS9FcUChGRFAvp9IYabT55Dx0RV43mswcP9bjXX9mpRcTKq91xz6+OPzXqnqWTSfLk8X0bLj4crTU+Pt1/FxE/Dw7B0eaQ+KNuxj/w6lgOhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhobcAkUITKcefDcAAAAAAElFTkSuQmCC',
+  iiith:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAIAAAC2BqGFAAABnUlEQVR4nO3cMUrDYBiA4bSIR/AQrhXngicQ3Fy9RWcvUZy8gAdw6QH0Ip06SxEHQUQUdPBtrM8zJSGBjzc/f7ZMhsv7gd833fUA/4XQEaEjQkeEjggdEToidEToiNARoSNCR4SOCB0ROiJ0ROiI0BGhI0JHhI4IHRE6InRE6IjQEaEjQkeEjggdEToidEToiNARoSNCR4SOCB0ROiJ0ROiI0BGhI0JHhI4IHRE6InRE6IjQEaEjQkeEjggdEToidGSkoTfL+acH5ydHq8VstZhtb89eDy5Oj97u+fDIqBzseoCfuXtY3z2sh2HYLOfz68fXizdXxzsd6ltGuqL3j9CRP7Z1fOrwYLpazN6f7nCYr+xD6Kft89t+PYz1YzjGl7+XhI5M/Ki7YUVHhI4IHRE6InRE6IjQEaEjQkeEjggdEToidEToiNARoSNCR4SOCB0ROiJ0ROiI0BGhI0JHhI4IHRE6InRE6IjQEaEjQkeEjggdEToidEToiNARoSNCR4SOCB0ROiJ0ROiI0BGhI0JHhI4IHRE6InRE6MgLLxsmDbeO2FgAAAAASUVORK5CYII=',
+  iitb:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAIAAAC2BqGFAAAB5klEQVR4nO3csSuEARyH8e8hTLJKGZQRk02S/8CojMqizmgy+wOMJpvFFWWUOpPxyiTKYqJuMog7gyslr/F53zvPZ3p7p29Pb7/xrXXrEWCo7AH/haEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGmJoiKEhhoYYGjJS9oA/HbSzN/n9sLCelXqSzC7n4TpJmofZPM7jTWq1jE/kYj+35yXu/UO1Q//QaqTVSJKDdg5Xey83jnrP04vZOqts6AE6HU+tdN7LHlFogELPreV0t+wRhfrqdPxqeDQ7VxkZy8xS7i4rezr6P/THW+9GT82n3ix5TLEBOh2vL3m+L3tEof7/or9OR7eTJCfbZa8pVPNH3YwBOh3VZmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmiIoSGGhhgaYmjIJwSrMfDQpDLQAAAAAElFTkSuQmCC',
+};
+
 const researchExperiences = [
   {
     title: 'Embodied AI Intern',
@@ -207,8 +216,8 @@ const researchExperiences = [
     summary:
       'Extended Moto-VLA with contrastive learning and in-context memory for retrieval-augmented VLA control.',
     image: {
-      src: 'https://placehold.co/120x120?text=NTU',
-      alt: 'Placeholder logo for NTU Singapore',
+      src: timelineLogos.ntu,
+      alt: 'NTU Singapore logo',
     },
   },
   {
@@ -218,8 +227,8 @@ const researchExperiences = [
     summary:
       'Designed a contract-validated visual HRL framework for long-horizon manipulation tasks using MoE and SmolVLA controllers.',
     image: {
-      src: 'https://placehold.co/120x120?text=IIIT',
-      alt: 'Placeholder logo for IIIT Hyderabad',
+      src: timelineLogos.iiith,
+      alt: 'IIIT Hyderabad logo',
     },
   },
   {
@@ -240,8 +249,8 @@ const researchExperiences = [
     summary:
       'Developed AURASeg, a model for drivable area segmentation, outperforming YOLOP in mIoU and F1-score.',
     image: {
-      src: 'https://placehold.co/120x120?text=IIT+B',
-      alt: 'Placeholder logo for IIT Bombay',
+      src: timelineLogos.iitb,
+      alt: 'IIT Bombay logo',
     },
   },
 ];

--- a/assets/style.css
+++ b/assets/style.css
@@ -1514,7 +1514,7 @@ body[data-theme='light'] .project-case__meta-block {
 .timeline-image img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .timeline-content {


### PR DESCRIPTION
## Summary
- embed the NTU, IIIT Hyderabad, and IIT Bombay logos for the research timeline directly in `assets/script.js`
- remove the standalone PNG logo files so the pull request no longer introduces binary assets

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e03f24b6c8832ca70ada0ab5e6670d