### PR TITLE
Increase timeline logo footprint and simplify publication cards

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -229,7 +229,7 @@ const researchExperiences = [
     summary:
       'Developed a lightweight GRU for real-time torque prediction in robotic exoskeletons with a fuzzy logic-based control system.',
     image: {
-      src: 'monash.svg',
+      src: 'monash.png',
       alt: 'Monash University logo',
     },
   },
@@ -281,8 +281,8 @@ if (researchTimeline) {
     description.className = 'timeline-description';
     description.textContent = experience.summary;
 
-    content.append(meta, heading, description);
-    item.append(imageWrapper, content);
+    content.append(imageWrapper, meta, heading, description);
+    item.append(content);
     researchTimeline.appendChild(item);
   });
 
@@ -323,11 +323,12 @@ const publicationGroups = [
         authors: 'N. Vijayakumar, R. Li, Z. Wang*',
         venue: 'IROS · 2026 (target)',
         status: 'Manuscript drafting',
-        summary:
-          'Retrieval-augmented visual-language-action policy that composes latent actions using on-the-fly memory tokens for long-horizon manipulation.',
-        highlights: [
-          'Contrastive retrieval bank distilled from teleoperation rollouts.',
-          'Memory prompting keeps novel task success stable with minimal finetuning.',
+        links: [
+          { label: 'arXiv (soon)', href: null },
+          {
+            label: 'Project Page',
+            href: 'https://narendhiranv04.github.io/#projects',
+          },
         ],
       },
       {
@@ -336,11 +337,12 @@ const publicationGroups = [
         authors: 'N. Vijayakumar, P. Ojha, G. Varma, A. Thomas*',
         venue: 'RA-L · 2025 (target)',
         status: 'Experiments wrapping up',
-        summary:
-          'Mixture-of-experts reinforcement learning stack that enforces contract-based guarantees when sequencing manipulation skills.',
-        highlights: [
-          'Safety contracts for reachability and force compliance baked into option selection.',
-          'Bridges sim-to-real with curriculum resets and human-in-the-loop validation.',
+        links: [
+          { label: 'arXiv (soon)', href: null },
+          {
+            label: 'Project Page',
+            href: 'https://narendhiranv04.github.io/#projects',
+          },
         ],
       },
     ],
@@ -356,11 +358,12 @@ const publicationGroups = [
         authors: 'C. Perera, N. Vijayakumar, A. Agape*',
         venue: 'IEEE TNNLS · 2025 (under review)',
         status: 'Initial review cycle',
-        summary:
-          'Lightweight hybrid estimator for exoskeleton torque prediction that blends fuzzy rules with recurrent dynamics for comfort-critical assistive walking.',
-        highlights: [
-          'Adaptive membership functions tuned for sit-to-walk transitions.',
-          'Embedded deployment on STM32 with <2 ms inference latency.',
+        links: [
+          { label: 'arXiv (soon)', href: null },
+          {
+            label: 'Project Page',
+            href: 'https://narendhiranv04.github.io/#projects',
+          },
         ],
       },
       {
@@ -369,11 +372,12 @@ const publicationGroups = [
         authors: 'N. Vijayakumar*, M. Sridevi',
         venue: 'Signal, Image and Video Processing · 2025 (under review)',
         status: 'Awaiting reviewer scores',
-        summary:
-          'Semantic segmentation pipeline for drivable area detection that sharpens occlusion boundaries with residual refinement.',
-        highlights: [
-          'Dual-branch attention for balancing texture cues and layout context.',
-          'Residual boundary assist improves edge IoU on nuScenes val split.',
+        links: [
+          { label: 'arXiv (soon)', href: null },
+          {
+            label: 'Project Page',
+            href: 'https://narendhiranv04.github.io/#projects',
+          },
         ],
       },
       {
@@ -381,11 +385,12 @@ const publicationGroups = [
         authors: 'N. Vijayakumar*, I. Ravikumar, R. Sundhar',
         venue: 'ICMRAE · 2025 (under review)',
         status: 'Camera-ready pending',
-        summary:
-          'Micro air vehicle platform with adaptive waypoint planning and robust failsafes for indoor autonomy demos.',
-        highlights: [
-          'On-board route planner adapts to moving obstacles in 3D grids.',
-          'Flight-tested guidance stack with redundant telemetry and watchdogs.',
+        links: [
+          { label: 'arXiv (soon)', href: null },
+          {
+            label: 'Project Page',
+            href: 'https://narendhiranv04.github.io/#projects',
+          },
         ],
       },
     ],
@@ -448,23 +453,33 @@ if (publicationContainer) {
       authors.className = 'publication-card__authors';
       authors.textContent = item.authors;
 
-      const summary = document.createElement('p');
-      summary.className = 'publication-card__summary';
-      summary.textContent = item.summary;
+      listItem.append(meta, title, authors);
 
-      listItem.append(meta, title, authors, summary);
+      if (Array.isArray(item.links) && item.links.length) {
+        const actions = document.createElement('div');
+        actions.className = 'publication-card__actions';
 
-      if (Array.isArray(item.highlights) && item.highlights.length) {
-        const highlights = document.createElement('ul');
-        highlights.className = 'publication-card__highlights';
+        item.links.forEach((link) => {
+          let action;
 
-        item.highlights.forEach((highlight) => {
-          const highlightItem = document.createElement('li');
-          highlightItem.textContent = highlight;
-          highlights.appendChild(highlightItem);
+          if (link.href) {
+            action = document.createElement('a');
+            action.href = link.href;
+            action.target = '_blank';
+            action.rel = 'noopener';
+          } else {
+            action = document.createElement('button');
+            action.type = 'button';
+            action.disabled = true;
+            action.setAttribute('aria-disabled', 'true');
+          }
+
+          action.className = 'publication-card__action';
+          action.textContent = link.label;
+          actions.appendChild(action);
         });
 
-        listItem.appendChild(highlights);
+        listItem.appendChild(actions);
       }
 
       list.appendChild(listItem);

--- a/assets/style.css
+++ b/assets/style.css
@@ -714,29 +714,52 @@ body[data-theme='light'] .publication-card {
   font-size: 0.95rem;
 }
 
-.publication-card__summary {
-  margin: 0;
-  color: var(--color-text);
-  font-size: 1rem;
-  line-height: 1.6;
+.publication-card__actions {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-.publication-card__highlights {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: grid;
-  gap: 0.45rem;
+.publication-card__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-heading);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color var(--transition), background var(--transition), color var(--transition),
+    transform var(--transition);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a.publication-card__action:hover,
+a.publication-card__action:focus-visible {
+  border-color: transparent;
+  background: var(--color-accent);
+  color: var(--color-button-text);
+  transform: translateY(-1px);
+}
+
+button.publication-card__action {
+  font: inherit;
+  background: transparent;
+}
+
+button.publication-card__action[disabled] {
+  cursor: not-allowed;
+  border-style: dashed;
+  border-color: var(--color-border);
   color: var(--color-muted);
-  font-size: 0.92rem;
-}
-
-.publication-card__highlights li {
-  margin: 0;
-  position: relative;
-}
-
-.publication-card__highlights li::marker {
-  color: var(--color-accent);
+  opacity: 0.7;
 }
 
 @media (max-width: 720px) {
@@ -1490,33 +1513,23 @@ body[data-theme='light'] .project-case__meta-block {
 }
 
 .timeline-image {
-  position: absolute;
-  top: -12px;
-  width: 96px;
-  height: 96px;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 2px solid rgba(123, 131, 255, 0.32);
-  background: var(--color-surface);
-  display: grid;
-  place-items: center;
-  padding: 12px;
-  box-shadow: var(--shadow-sm);
-}
-
-.timeline-item:nth-child(odd) .timeline-image {
-  right: -152px;
-}
-
-.timeline-item:nth-child(even) .timeline-image {
-  left: -152px;
+  width: 100%;
+  margin: -1.5rem -1.5rem 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: calc(var(--radius-lg) - 4px) calc(var(--radius-lg) - 4px) 0 0;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-section);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .timeline-image img {
-  width: auto;
+  width: clamp(120px, 50%, 200px);
+  max-width: 100%;
   height: auto;
-  max-width: 80%;
-  max-height: 80%;
+  max-height: clamp(72px, 14vw, 110px);
   object-fit: contain;
 }
 
@@ -1529,6 +1542,7 @@ body[data-theme='light'] .project-case__meta-block {
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 0.65rem;
+  overflow: hidden;
 }
 
 .timeline-meta {
@@ -1574,17 +1588,8 @@ body[data-theme='light'] .project-case__meta-block {
   }
 
   .timeline-image {
-    position: static;
-    width: 80px;
-    height: 80px;
-    margin-bottom: 1rem;
-    padding: 10px;
-  }
-
-  .timeline-item:nth-child(odd) .timeline-image,
-  .timeline-item:nth-child(even) .timeline-image {
-    right: auto;
-    left: auto;
+    margin: -1.5rem -1.5rem 1rem;
+    padding: clamp(1.25rem, 5vw, 1.75rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge research timeline logos to span the full card width and ensure the Monash asset renders correctly
- reflow publication cards to show action chips instead of long summaries while preserving venue metadata
- add styling for the new publication actions so the buttons match the existing aesthetic

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e56eaf6608832c8d05eed9ce9446cf