### PR TITLE
Center research timeline cards

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1471,6 +1471,8 @@ body[data-theme='light'] .project-case__meta-block {
   position: relative;
   width: 50%;
   padding: 0 2.75rem 2.75rem;
+  display: flex;
+  justify-content: flex-end;
   opacity: 0;
   transform: translateY(48px);
   transition: transform 0.6s ease, opacity 0.6s ease;
@@ -1489,6 +1491,7 @@ body[data-theme='light'] .project-case__meta-block {
 
 .timeline-item:nth-child(even) {
   left: 50%;
+  justify-content: flex-start;
 }
 
 .timeline-item::before {
@@ -1543,6 +1546,7 @@ body[data-theme='light'] .project-case__meta-block {
   display: grid;
   gap: 0.65rem;
   overflow: hidden;
+  width: min(100%, 420px);
 }
 
 .timeline-meta {
@@ -1577,6 +1581,7 @@ body[data-theme='light'] .project-case__meta-block {
   .timeline-item {
     width: 100%;
     padding: 0 0 2.5rem 3.5rem;
+    display: block;
   }
 
   .timeline-item:nth-child(even) {
@@ -1590,6 +1595,10 @@ body[data-theme='light'] .project-case__meta-block {
   .timeline-image {
     margin: -1.5rem -1.5rem 1rem;
     padding: clamp(1.25rem, 5vw, 1.75rem);
+  }
+
+  .timeline-content {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- align the research timeline cards toward the center line by using a flex layout with constrained card widths
- keep the mobile layout intact by reverting to a block layout at narrow breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5714b9b30832ca794c69a1453cbbd