### PR TITLE
Enlarge research timeline logos and layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1517,8 +1517,8 @@ body[data-theme='light'] .project-case__meta-block {
 
 .timeline-image {
   width: 100%;
-  margin: -1.5rem -1.5rem 1.25rem;
-  padding: clamp(1.5rem, 4vw, 2.25rem);
+  margin: -1.5rem -1.5rem 1.5rem;
+  padding: clamp(1.75rem, 5vw, 2.75rem);
   border-radius: calc(var(--radius-lg) - 4px) calc(var(--radius-lg) - 4px) 0 0;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-section);
@@ -1529,10 +1529,10 @@ body[data-theme='light'] .project-case__meta-block {
 }
 
 .timeline-image img {
-  width: clamp(120px, 50%, 200px);
+  width: clamp(180px, 70%, 320px);
   max-width: 100%;
   height: auto;
-  max-height: clamp(72px, 14vw, 110px);
+  max-height: clamp(120px, 20vw, 220px);
   object-fit: contain;
 }
 
@@ -1546,7 +1546,7 @@ body[data-theme='light'] .project-case__meta-block {
   display: grid;
   gap: 0.65rem;
   overflow: hidden;
-  width: min(100%, 420px);
+  width: min(100%, 520px);
 }
 
 .timeline-meta {
@@ -1594,11 +1594,16 @@ body[data-theme='light'] .project-case__meta-block {
 
   .timeline-image {
     margin: -1.5rem -1.5rem 1rem;
-    padding: clamp(1.25rem, 5vw, 1.75rem);
+    padding: clamp(1.5rem, 6vw, 2rem);
   }
 
   .timeline-content {
     width: 100%;
+  }
+
+  .timeline-image img {
+    width: clamp(160px, 80%, 260px);
+    max-height: clamp(110px, 32vw, 200px);
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge research timeline logos with increased padding for better visibility
- allow timeline cards to span the full column width to remove leftover gutter space

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e572d994d4832c8fae5588fd0bd548