### PR TITLE
Rebalance research timeline spacing and logos

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1490,13 +1490,15 @@ body[data-theme='light'] .project-case__meta-block {
 .timeline-item:nth-child(odd) {
   left: 0;
   text-align: left;
-  padding-right: 0;
+  padding-right: clamp(3rem, 6vw, 4rem);
+  padding-left: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .timeline-item:nth-child(even) {
   left: 50%;
   justify-content: flex-start;
-  padding-left: 0;
+  padding-left: clamp(3rem, 6vw, 4rem);
+  padding-right: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .timeline-item::before {
@@ -1534,10 +1536,9 @@ body[data-theme='light'] .project-case__meta-block {
 }
 
 .timeline-image img {
-  width: clamp(180px, 70%, 320px);
-  max-width: 100%;
+  width: 100%;
   height: auto;
-  max-height: clamp(120px, 20vw, 220px);
+  max-height: clamp(140px, 26vw, 260px);
   object-fit: contain;
 }
 
@@ -1590,6 +1591,11 @@ body[data-theme='light'] .project-case__meta-block {
     display: block;
   }
 
+  .timeline-item:nth-child(odd) {
+    padding-left: 3.5rem;
+    padding-right: 0;
+  }
+
   .timeline-item:last-child {
     padding-bottom: 0;
   }
@@ -1597,10 +1603,19 @@ body[data-theme='light'] .project-case__meta-block {
   .timeline-item:nth-child(even) {
     left: 0;
     padding-left: 3.5rem;
+    padding-right: 0;
   }
 
   .timeline-item::before {
     left: 8px;
+  }
+
+  .timeline-item:nth-child(odd) .timeline-image,
+  .timeline-item:nth-child(odd) .timeline-content,
+  .timeline-item:nth-child(even) .timeline-image,
+  .timeline-item:nth-child(even) .timeline-content {
+    margin-left: 0;
+    margin-right: 0;
   }
 
   .timeline-image {
@@ -1612,10 +1627,10 @@ body[data-theme='light'] .project-case__meta-block {
     width: 100%;
   }
 
-  .timeline-image img {
-    width: clamp(160px, 80%, 260px);
-    max-height: clamp(110px, 32vw, 200px);
-  }
+    .timeline-image img {
+      width: 100%;
+      max-height: clamp(120px, 36vw, 220px);
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- shift desktop timeline cards away from the central spine using asymmetric padding instead of ad-hoc margins
- allow timeline logos to span the full card width on all breakpoints while retaining height limits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e596ba843c832cb164d2f27ccd4fb8